### PR TITLE
Introduce state machines

### DIFF
--- a/eduvpn/app.py
+++ b/eduvpn/app.py
@@ -44,6 +44,7 @@ class Application:
         Load the lists of organisations and servers.
         """
         self.server_db.update()
+        self.interface_transition_threadsafe('server_db_finished_loading')
 
     @property
     def network_state(self):

--- a/eduvpn/app.py
+++ b/eduvpn/app.py
@@ -1,0 +1,93 @@
+import logging
+from .server import ServerDatabase
+from .storage import get_uuid
+from .state_machine import StateMachine, InvalidStateTransition
+from .utils import run_in_background_thread
+
+
+logger = logging.getLogger(__name__)
+
+
+class Application:
+    def __init__(self):
+        from .network import InitialNetworkState
+        from .interface import InitialInterfaceState
+        self.network_state_machine = StateMachine(InitialNetworkState())
+        self.interface_state_machine = StateMachine(InitialInterfaceState())
+        self.server_db = ServerDatabase()
+        self.current_network_uuid = None
+
+    def initialize(self, make_func_threadsafe):
+        self.initialize_network(make_func_threadsafe)
+        self.initialize_server_db()
+
+    @run_in_background_thread
+    def initialize_network(self, make_func_threadsafe):
+        """
+        Determine the current network state.
+        """
+        # Check if a previous network profile exists.
+        self.current_network_uuid = get_uuid()
+        threadsafe_transition = make_func_threadsafe(self.network_transition)
+        if self.current_network_uuid:
+            if 0:  # TODO
+                threadsafe_transition('found_active_connection')
+            else:
+                threadsafe_transition('found_previous_connection')
+        else:
+            threadsafe_transition('no_previous_connection_found')
+
+    @run_in_background_thread
+    def initialize_server_db(self):
+        """
+        Load the lists of organisations and servers.
+        """
+        self.server_db.update()
+
+    @property
+    def network_state(self):
+        """
+        Get the current state of the network.
+        """
+        return self.network_state_machine.state
+
+    @property
+    def interface_state(self):
+        """
+        Get the current state of the interface.
+        """
+        return self.interface_state_machine.state
+
+    def connect_state_transition_callbacks(self, obj):
+        """
+        Register all state transition callback methods decorated with
+        `@transition_callback()` and `@transition_edge_callback()` of an object.
+        """
+        from .network import NetworkState
+        self.network_state_machine.connect_object_callbacks(obj, NetworkState)
+        from .interface import InterfaceState
+        self.interface_state_machine.connect_object_callbacks(obj, InterfaceState)
+
+    def network_transition(self, transition, *args, **kwargs):
+        """
+        Perform a transition on the network state.
+        """
+        logger.info(f'network transitioning: {self.network_state} -> {transition}')
+        try:
+            self.network_state_machine.transition(transition, self, *args, **kwargs)
+        except InvalidStateTransition:
+            logger.error(f'invalid network state transition: {self.network_state} -> {transition}')
+        else:
+            logger.info(f'network transitioned: {transition} -> {self.network_state}')
+
+    def interface_transition(self, transition, *args, **kwargs):
+        """
+        Perform a transition on the interface state.
+        """
+        logger.info(f'interface transitioning: {self.interface_state} -> {transition}')
+        try:
+            self.interface_state_machine.transition(transition, self, *args, **kwargs)
+        except InvalidStateTransition:
+            logger.error(f'invalid interface state transition: {self.interface_state} -> {transition}')
+        else:
+            logger.info(f'interface transitioned: {transition} -> {self.interface_state}')

--- a/eduvpn/app.py
+++ b/eduvpn/app.py
@@ -63,47 +63,63 @@ class Application:
     def connect_state_transition_callbacks(self, obj):
         """
         Register all state transition callback methods decorated with
-        `@transition_callback()` and `@transition_edge_callback()` of an object.
+        `@transition_callback()` and `@transition_edge_callback()`
+        of an object.
         """
         from .network import NetworkState
         self.network_state_machine.connect_object_callbacks(obj, NetworkState)
         from .interface import InterfaceState
-        self.interface_state_machine.connect_object_callbacks(obj, InterfaceState)
+        self.interface_state_machine.connect_object_callbacks(
+            obj, InterfaceState)
 
     def network_transition(self, transition, *args, **kwargs):
         """
         Perform a transition on the network state.
         """
-        logger.info(f'network transitioning: {self.network_state} -> {transition}')
+        logger.info(
+            f'network transitioning: '
+            f'{self.network_state} -> {transition}')
         try:
-            self.network_state_machine.transition(transition, self, *args, **kwargs)
+            self.network_state_machine.transition(
+                transition, self, *args, **kwargs)
         except InvalidStateTransition:
-            logger.error(f'invalid network state transition: {self.network_state} -> {transition}')
+            logger.error(
+                f'invalid network state transition: '
+                f'{self.network_state} -> {transition}')
         else:
-            logger.info(f'network transitioned: {transition} -> {self.network_state}')
+            logger.info(
+                f'network transitioned: '
+                f'{transition} -> {self.network_state}')
 
     def interface_transition(self, transition, *args, **kwargs):
         """
         Perform a transition on the interface state.
         """
-        logger.info(f'interface transitioning: {self.interface_state} -> {transition}')
+        logger.info(
+            f'interface transitioning: '
+            f'{self.interface_state} -> {transition}')
         try:
-            self.interface_state_machine.transition(transition, self, *args, **kwargs)
+            self.interface_state_machine.transition(
+                transition, self, *args, **kwargs)
         except InvalidStateTransition:
-            logger.error(f'invalid interface state transition: {self.interface_state} -> {transition}')
+            logger.error(
+                f'invalid interface state transition: '
+                f'{self.interface_state} -> {transition}')
         else:
-            logger.info(f'interface transitioned: {transition} -> {self.interface_state}')
+            logger.info(
+                f'interface transitioned: '
+                f'{transition} -> {self.interface_state}')
 
     def network_transition_threadsafe(self, transition, *args, **kwargs):
         """
         Threadsafe version of `network_transition()`.
         """
-        network_transition = self.make_func_threadsafe(self.network_transition)
-        network_transition(transition, *args, **kwargs)
+        transit = self.make_func_threadsafe(self.network_transition)
+        transit(transition, *args, **kwargs)
 
     def interface_transition_threadsafe(self, transition, *args, **kwargs):
         """
         Threadsafe version of `network_transition()`.
         """
-        interface_transition = self.make_func_threadsafe(self.interface_transition)
-        interface_transition(transition, *args, **kwargs)
+        transit = self.make_func_threadsafe(self.interface_transition)
+        transit(transition, *args, **kwargs)

--- a/eduvpn/interface.py
+++ b/eduvpn/interface.py
@@ -1,0 +1,205 @@
+from typing import Optional, List
+import logging
+from .storage import get_current_metadata
+from .state_machine import BaseState
+from .app import Application
+from .server import Server
+
+
+logger = logging.getLogger(__name__)
+
+
+class InterfaceState(BaseState):
+    """
+    Base class for all interface states.
+    """
+
+    def toggle_settings(self, app: Application) -> 'InterfaceState':
+        return ConfigureSettings(self)
+
+
+class InitialInterfaceState(InterfaceState):
+    """
+    The state of the interface when the app starts.
+
+    This is a transient state until
+    the actual first state has been determined.
+    """
+
+    def found_active_connection(self, app: Application, server: Server) -> InterfaceState:
+        """
+        An connection is already active, show its details.
+        """
+        return ConnectionStatus(server)
+
+    def no_active_connection_found(self, app: Application) -> InterfaceState:
+        """
+        No connection is currently active, go to the main state.
+        """
+        return go_to_main_state(app)
+
+
+def go_to_main_state(app: Application) -> InterfaceState:
+    """
+    If any servers have been configured, show the main state to select one.
+    Otherwise, allow the user to configure a new server.
+    """
+    configured_servers = []  # TODO
+    if configured_servers:
+        return MainState(servers=configured_servers)
+    else:
+        return ConfigurePredefinedServer()
+
+
+def connect_to_server(app: Application, server: Server) -> InterfaceState:
+    if not hasattr(server, 'oauth_login_url'):
+        # This server doesn't require OAuth setup
+        # TODO make connection
+        return ConnectionStatus(server)
+    metadata = get_current_metadata(server.oauth_login_url)
+    if metadata:
+        # We've already configured this server.
+        # TODO make connection
+        return ConnectionStatus(server)
+    else:
+        # This is a new server.
+        # TODO make connection
+        return OAuthSetup(server)
+
+
+class MainState(InterfaceState):
+    """
+    The home state of the app.
+
+    Present a list of configured servers to start a connection.
+    """
+
+    def __init__(self, servers: List[Server]):
+        self.servers = servers
+
+    def configure_new_server(self, app: Application) -> InterfaceState:
+        return ConfigurePredefinedServer()
+
+    def connect_to_server(self, app: Application, server: Server) -> InterfaceState:
+        return connect_to_server(app, server)
+
+
+def enter_search_query(app: Application, search_query: str) -> InterfaceState:
+    """
+    Enter a search query for a predefined server.
+    """
+    if search_query:
+        results = list(app.server_db.search(search_query))
+    else:
+        results = None
+    return ConfigurePredefinedServer(search_query, results)
+
+
+def enter_custom_address(app: Application, address: str) -> InterfaceState:
+    """
+    Enter an address for a custom server.
+    """
+    return ConfigureCustomServer(address)
+
+
+class ConfigurePredefinedServer(InterfaceState):
+    """
+    Select a server to configure
+    from a list of known servers.
+    """
+
+    def __init__(self, search_query: str = '', results: Optional[Server] = None):
+        self.search_query = search_query
+        self.results = results
+
+    def __repr__(self):
+        if self.results is None:
+            results = None
+        else:
+            # Don't include the long list of results.
+            results = len(self.results)
+        return f"<ConfigurePredefinedServer search_query={self.search_query!r} results={results}>"
+
+    def enter_search_query(self, app: Application, search_query: str) -> InterfaceState:
+        return enter_search_query(app, search_query)
+
+    def enter_custom_address(self, app: Application, address: str) -> InterfaceState:
+        return enter_custom_address(app, address)
+
+    def connect_to_server(self, app: Application, server: Server) -> InterfaceState:
+        return connect_to_server(app, server)
+
+
+class ConfigureCustomServer(InterfaceState):
+    """
+    Select a custom server to configure
+    by providing its address.
+    """
+
+    def __init__(self, address: str):
+        self.address = address
+
+    def enter_search_query(self, app: Application, search_query: str) -> InterfaceState:
+        return enter_search_query(app, search_query)
+
+    def enter_custom_address(self, app: Application, address: str) -> InterfaceState:
+        return enter_custom_address(app, address)
+
+    def connect_to_server(self, app: Application, server: Server):
+        return connect_to_server(app, server)
+
+
+class OAuthSetup(InterfaceState):
+    """
+    Allow the user to log into the VPN server using their browser.
+    """
+
+    def __init__(self, server: Server):
+        self.server = server
+
+    def oauth_setup_cancel(self, app: Application) -> InterfaceState:
+        return go_to_main_state(app)
+
+    def oauth_setup_success(self, app: Application) -> InterfaceState:
+        return ConnectionStatus(self.server)
+
+    def oauth_setup_failure(self, app: Application, error: str) -> InterfaceState:
+        return OAuthFailed(self.server, error)
+
+
+class OAuthFailed(InterfaceState):
+    """
+    Inform the user that the OAuth process failed,
+    and allow them to retry or cancel the process.
+    """
+
+    def __init__(self, server: Server, error: str):
+        self.server = server
+        self.error = error
+
+    def oauth_setup_cancel(self, app: Application) -> InterfaceState:
+        return go_to_main_state(app)
+
+    def oauth_setup_retry(self, app: Application) -> InterfaceState:
+        return OAuthSetup(self.server)
+
+
+class ConfigureSettings(InterfaceState):
+    """
+    Allow the user to configure the application settings.
+    """
+
+    def __init__(self, previous_state):
+        self.previous_state = previous_state
+
+    def toggle_settings(self, app: Application) -> InterfaceState:
+        return self.previous_state
+
+
+class ConnectionStatus(InterfaceState):
+    """
+    Show info on the active connection status.
+    """
+
+    def __init__(self, server: Server):
+        self.server = server

--- a/eduvpn/interface.py
+++ b/eduvpn/interface.py
@@ -50,7 +50,7 @@ def go_to_main_state(app: Application) -> InterfaceState:
     If any servers have been configured, show the main state to select one.
     Otherwise, allow the user to configure a new server.
     """
-    configured_servers = []  # TODO
+    configured_servers: List[Server] = []  # TODO
     if configured_servers:
         return MainState(servers=configured_servers)
     else:
@@ -62,7 +62,7 @@ def connect_to_server(app: Application, server: Server) -> InterfaceState:
         # This server doesn't require OAuth setup
         # TODO make connection
         return ConnectionStatus(server)
-    metadata = get_current_metadata(server.oauth_login_url)
+    metadata = get_current_metadata(server.oauth_login_url)  # type: ignore
     if metadata:
         # We've already configured this server.
         # TODO make connection
@@ -96,6 +96,7 @@ def enter_search_query(app: Application, search_query: str) -> InterfaceState:
     """
     Enter a search query for a predefined server.
     """
+    results: Optional[List[Server]]
     if search_query:
         if app.server_db.is_loaded:
             results = list(app.server_db.search(search_query))
@@ -152,7 +153,7 @@ class ConfigurePredefinedServer(InterfaceState):
 
     def __init__(self,
                  search_query: str = '',
-                 results: Optional[Server] = None):
+                 results: Optional[List[Server]] = None):
         self.search_query = search_query
         self.results = results
 

--- a/eduvpn/interface.py
+++ b/eduvpn/interface.py
@@ -30,7 +30,9 @@ class InitialInterfaceState(InterfaceState):
     the actual first state has been determined.
     """
 
-    def found_active_connection(self, app: Application, server: Server) -> InterfaceState:
+    def found_active_connection(self,
+                                app: Application,
+                                server: Server) -> InterfaceState:
         """
         An connection is already active, show its details.
         """
@@ -84,7 +86,9 @@ class MainState(InterfaceState):
     def configure_new_server(self, app: Application) -> InterfaceState:
         return ConfigurePredefinedServer()
 
-    def connect_to_server(self, app: Application, server: Server) -> InterfaceState:
+    def connect_to_server(self,
+                          app: Application,
+                          server: Server) -> InterfaceState:
         return connect_to_server(app, server)
 
 
@@ -119,13 +123,21 @@ class PendingConfigurePredefinedServer(InterfaceState):
     def __init__(self, search_query: str = ''):
         self.search_query = search_query
 
-    def enter_search_query(self, app: Application, search_query: str) -> InterfaceState:
+    def enter_search_query(self,
+                           app: Application,
+                           search_query: str,
+                           ) -> InterfaceState:
         return PendingConfigurePredefinedServer(search_query)
 
-    def enter_custom_address(self, app: Application, address: str) -> InterfaceState:
+    def enter_custom_address(self,
+                             app: Application,
+                             address: str,
+                             ) -> InterfaceState:
         return enter_custom_address(app, address)
 
-    def connect_to_server(self, app: Application, server: Server) -> InterfaceState:
+    def connect_to_server(self,
+                          app: Application,
+                          server: Server) -> InterfaceState:
         return connect_to_server(app, server)
 
     def server_db_finished_loading(self, app: Application) -> InterfaceState:
@@ -138,7 +150,9 @@ class ConfigurePredefinedServer(InterfaceState):
     from a list of known servers.
     """
 
-    def __init__(self, search_query: str = '', results: Optional[Server] = None):
+    def __init__(self,
+                 search_query: str = '',
+                 results: Optional[Server] = None):
         self.search_query = search_query
         self.results = results
 
@@ -148,15 +162,25 @@ class ConfigurePredefinedServer(InterfaceState):
         else:
             # Don't include the long list of results.
             results = len(self.results)
-        return f"<ConfigurePredefinedServer search_query={self.search_query!r} results={results}>"
+        return (
+            f"<ConfigurePredefinedServer"
+            f" search_query={self.search_query!r}"
+            f" results={results}>"
+        )
 
-    def enter_search_query(self, app: Application, search_query: str) -> InterfaceState:
+    def enter_search_query(self, app: Application,
+                           search_query: str,
+                           ) -> InterfaceState:
         return enter_search_query(app, search_query)
 
-    def enter_custom_address(self, app: Application, address: str) -> InterfaceState:
+    def enter_custom_address(self, app: Application,
+                             address: str,
+                             ) -> InterfaceState:
         return enter_custom_address(app, address)
 
-    def connect_to_server(self, app: Application, server: Server) -> InterfaceState:
+    def connect_to_server(self,
+                          app: Application,
+                          server: Server) -> InterfaceState:
         return connect_to_server(app, server)
 
 
@@ -169,13 +193,19 @@ class ConfigureCustomServer(InterfaceState):
     def __init__(self, address: str):
         self.address = address
 
-    def enter_search_query(self, app: Application, search_query: str) -> InterfaceState:
+    def enter_search_query(self, app: Application,
+                           search_query: str,
+                           ) -> InterfaceState:
         return enter_search_query(app, search_query)
 
-    def enter_custom_address(self, app: Application, address: str) -> InterfaceState:
+    def enter_custom_address(self, app: Application,
+                             address: str,
+                             ) -> InterfaceState:
         return enter_custom_address(app, address)
 
-    def connect_to_server(self, app: Application, server: Server):
+    def connect_to_server(self,
+                          app: Application,
+                          server: Server) -> InterfaceState:
         return connect_to_server(app, server)
 
 
@@ -201,7 +231,10 @@ class OAuthSetup(InterfaceState):
     def oauth_setup_success(self, app: Application) -> InterfaceState:
         return ConnectionStatus(self.server)
 
-    def oauth_setup_failure(self, app: Application, error: str) -> InterfaceState:
+    def oauth_setup_failure(self,
+                            app: Application,
+                            error: str,
+                            ) -> InterfaceState:
         return OAuthFailed(self.server, error)
 
 

--- a/eduvpn/network.py
+++ b/eduvpn/network.py
@@ -1,0 +1,172 @@
+import logging
+from .nm import get_client, activate_connection, deactivate_connection
+from .state_machine import BaseState
+from .app import Application
+from .server import Server
+
+
+logger = logging.getLogger(__name__)
+
+
+class NetworkState(BaseState):
+    """
+    Base class for all interface states.
+    """
+
+
+class InitialNetworkState(NetworkState):
+    """
+    The state of the network when the app starts.
+
+    This is a transient state until
+    the actual network state is obtained.
+    """
+
+    def found_active_connection(self, app: Application, server: Server) -> NetworkState:
+        """
+        An already active connection was found.
+        """
+        app.interface_transition('found_active_connection', server)
+        return ConnectedState(server)
+
+    def found_previous_connection(self, app: Application, server: Server) -> NetworkState:
+        """
+        A previously established connection was found.
+
+        This will be the default connection to start.
+        """
+        app.interface_transition('no_active_connection_found')
+        return DisconnectedState(server)
+
+    def no_previous_connection_found(self, app: Application) -> NetworkState:
+        """
+        No previously established connection was found.
+
+        This is probably the first time the app runs.
+        """
+        app.interface_transition('no_active_connection_found')
+        return UnconnectedState()
+
+
+class UnconnectedState(NetworkState):
+    """
+    There is no current connection active,
+    nor is there a configured connection available.
+
+    As soon as a server is chosen,
+    that becomes the default
+    and this state is no longer reached.
+    """
+
+    def connecting_to_server(self, app: Application, server: Server) -> NetworkState:
+        # TODO store this as the default server
+        return ConnectingState(server)
+
+
+def connect(app: Application, server: Server) -> NetworkState:
+    """
+    Estabilish a connection to the server.
+    """
+    client = get_client()
+    activate_connection(client, app.current_network_uuid)
+    return ConnectingState(self.server)
+
+
+def disconnect(app: Application, server: Server) -> NetworkState:
+    """
+    Break the connection to the server.
+    """
+    client = get_client()
+    deactivate_connection(client, app.current_network_uuid)
+    return DisconnectedState(self.server)
+
+
+class ConnectingState(NetworkState):
+    """
+    The network is currently trying to connect to a server.
+    """
+
+    def __init__(self, server: Server):
+        self.server = server
+
+    def disconnect(self, app: Application) -> NetworkState:
+        """
+        Abort connecting.
+        """
+        return disconnect(app, self.server)
+
+    def connection_established(self, app: Application) -> NetworkState:
+        """
+        The connection has been established.
+        """
+        return ConnectedState(self.server)
+
+    def connection_failed(self, app: Application) -> NetworkState:
+        """
+        The connection has been established.
+        """
+        return ConnectionErrorState(self.server)
+
+
+class ConnectedState(NetworkState):
+    """
+    The network is currently connected to a server.
+    """
+
+    def __init__(self, server: Server):
+        self.server = server
+        # TODO
+        # self.time_started =
+        # self.valid_until =
+        # self.bytes_received =
+        # self.bytes_uploaded =
+
+    def disconnect(self, app: Application) -> NetworkState:
+        return disconnect(app, self.server)
+
+    def certificate_expired(self, app: Application) -> NetworkState:
+        """
+        The certificate for this connection has expired.
+        """
+        return CertificateExpiredState(self.server)
+
+
+class DisconnectedState(NetworkState):
+    """
+    The network is currently connected to a server.
+    """
+
+    def __init__(self, server: Server):
+        self.server = server
+
+    def reconnect(self, app: Application) -> NetworkState:
+        return connect(app, self.server)
+
+
+class CertificateExpiredState(NetworkState):
+    """
+    The network is currently connected to a server.
+    """
+
+    def __init__(self, server: Server):
+        self.server = server
+
+    def renew_certificate(self, app: Application) -> NetworkState:
+        """
+        Re-estabilish a connection to the server.
+        """
+        # TODO perform actual renewal
+        return connect(app, self.server)
+
+
+class ConnectionErrorState(NetworkState):
+    """
+    The network is currently connected to a server.
+    """
+
+    def __init__(self, server: Server, error: str):
+        self.server = server
+        self.error = error
+
+    def reconnect(self, app: Application) -> NetworkState:
+        return connect(app, self.server)

--- a/eduvpn/network.py
+++ b/eduvpn/network.py
@@ -22,14 +22,20 @@ class InitialNetworkState(NetworkState):
     the actual network state is obtained.
     """
 
-    def found_active_connection(self, app: Application, server: Server) -> NetworkState:
+    def found_active_connection(self,
+                                app: Application,
+                                server: Server,
+                                ) -> NetworkState:
         """
         An already active connection was found.
         """
         app.interface_transition('found_active_connection', server)
         return ConnectedState(server)
 
-    def found_previous_connection(self, app: Application, server: Server) -> NetworkState:
+    def found_previous_connection(self,
+                                  app: Application,
+                                  server: Server,
+                                  ) -> NetworkState:
         """
         A previously established connection was found.
 
@@ -58,7 +64,10 @@ class UnconnectedState(NetworkState):
     and this state is no longer reached.
     """
 
-    def connecting_to_server(self, app: Application, server: Server) -> NetworkState:
+    def connecting_to_server(self,
+                             app: Application,
+                             server: Server,
+                             ) -> NetworkState:
         # TODO store this as the default server
         return ConnectingState(server)
 
@@ -69,7 +78,7 @@ def connect(app: Application, server: Server) -> NetworkState:
     """
     client = get_client()
     activate_connection(client, app.current_network_uuid)
-    return ConnectingState(self.server)
+    return ConnectingState(server)
 
 
 def disconnect(app: Application, server: Server) -> NetworkState:
@@ -78,7 +87,7 @@ def disconnect(app: Application, server: Server) -> NetworkState:
     """
     client = get_client()
     deactivate_connection(client, app.current_network_uuid)
-    return DisconnectedState(self.server)
+    return DisconnectedState(server)
 
 
 class ConnectingState(NetworkState):
@@ -105,7 +114,8 @@ class ConnectingState(NetworkState):
         """
         The connection has been established.
         """
-        return ConnectionErrorState(self.server)
+        error = ""  # TODO
+        return ConnectionErrorState(self.server, error)
 
 
 class ConnectedState(NetworkState):

--- a/eduvpn/server.py
+++ b/eduvpn/server.py
@@ -80,7 +80,7 @@ class OrganisationServer:
                  secure_internet_home: str,
                  display_name: Union[str, Dict[str, str]],
                  org_id: str,
-                 keyword_list: List[str] = []):
+                 keyword_list: Dict[str, str] = {}):
         self.secure_internet_home = secure_internet_home
         self.display_name = display_name
         self.org_id = org_id
@@ -133,11 +133,17 @@ server_types = [
 
 
 # typing aliases
-ServerType = Any
-Server = Union[tuple(server_types)]
+Server = Union[
+    InstituteAccessServer,
+    OrganisationServer,
+    CustomServer,
+]
+ServerType = Type[Server]
 
 
-def group_servers_by_type(servers: Iterable[Server]) -> Dict[Type, Server]:
+def group_servers_by_type(
+        servers: Iterable[Server]) -> Dict[ServerType, List[Server]]:
+    groups: Dict[ServerType, List[Server]]
     groups = {server_type: [] for server_type in server_types}
     for server in servers:
         groups[type(server)].append(server)
@@ -147,7 +153,8 @@ def group_servers_by_type(servers: Iterable[Server]) -> Dict[Type, Server]:
 def is_search_match(server: Server, query: str) -> bool:
     if hasattr(server, 'search_texts'):
         return any(query.lower() in search_text.lower()
-                   for search_text in server.search_texts)
+                   for search_text
+                   in server.search_texts)  # type: ignore
     else:
         return False
 

--- a/eduvpn/server.py
+++ b/eduvpn/server.py
@@ -156,6 +156,7 @@ class ServerDatabase:
     def __init__(self):
         # TODO load the servers from a cache
         self.servers = []
+        self.is_loaded = False
 
     def update(self):
         """
@@ -183,6 +184,7 @@ class ServerDatabase:
         # Atomic update of server map.
         # TODO keep custom other servers
         self.servers = new_servers
+        self.is_loaded = True
 
     def all(self) -> Iterable[Server]:
         "Return all servers."

--- a/eduvpn/server.py
+++ b/eduvpn/server.py
@@ -1,0 +1,198 @@
+from typing import Any, Union, Optional, Iterable, List, Dict, Type
+from eduvpn.remote import list_servers, list_organisations
+from eduvpn.i18n import extract_translation
+from eduvpn.settings import SERVER_URI, ORGANISATION_URI
+
+
+class InstituteAccessServer:
+    """
+    A record from: https://disco.eduvpn.org/v2/server_list.json
+    where: server_type == "institute_access"
+    """
+
+    def __init__(self,
+                 base_url: str,
+                 display_name: Union[str, Dict[str, str]],
+                 support_contact: List[str] = [],
+                 keyword_list: Optional[str] = None):
+        self.base_url = base_url
+        self.display_name = display_name
+        self.support_contact = support_contact
+        self.keyword_list = keyword_list
+
+    def __str__(self):
+        return extract_translation(self.display_name)
+
+    def __repr__(self):
+        return f"<InstituteAccessServer {str(self)!r}>"
+
+    @property
+    def keyword(self) -> Optional[str]:
+        return self.keyword_list
+
+    @property
+    def search_texts(self):
+        texts = [str(self)]
+        if self.keyword:
+            texts.append(self.keyword)
+        return texts
+
+    @property
+    def oauth_login_url(self):
+        return self.base_url
+
+
+class SecureInternetServer:
+    """
+    A record from: https://disco.eduvpn.org/v2/server_list.json
+    where: server_type == "secure_internet"
+    """
+
+    def __init__(self,
+                 base_url: str,
+                 public_key_list: List[str],
+                 country_code: str,
+                 support_contact: List[str] = [],
+                 authentication_url_template: Optional[str] = None):
+        self.base_url = base_url
+        self.public_key_list = public_key_list
+        self.support_contact = support_contact
+        self.country_code = country_code
+        self.authentication_url_template = authentication_url_template
+
+    def __str__(self):
+        return self.base_url  # TODO
+
+    def __repr__(self):
+        return f"<SecureInternetServer {str(self)!r}>"
+
+    @property
+    def oauth_login_url(self):
+        return self.base_url
+
+
+class OrganisationServer:
+    """
+    A record from: https://disco.eduvpn.org/v2/organization_list.json
+    """
+
+    def __init__(self,
+                 secure_internet_home: str,
+                 display_name: Union[str, Dict[str, str]],
+                 org_id: str,
+                 keyword_list: List[str] = []):
+        self.secure_internet_home = secure_internet_home
+        self.display_name = display_name
+        self.org_id = org_id
+        self.keyword_list = keyword_list
+
+    def __str__(self):
+        return extract_translation(self.display_name)
+
+    def __repr__(self):
+        return f"<OrganisationServer {str(self)!r}>"
+
+    @property
+    def keyword(self) -> Optional[str]:
+        if self.keyword_list:
+            return extract_translation(self.keyword_list)
+        return None
+
+    @property
+    def search_texts(self):
+        texts = [str(self)]
+        if self.keyword:
+            texts.append(self.keyword)
+        return texts
+
+    @property
+    def oauth_login_url(self):
+        return self.secure_internet_home
+
+
+class CustomServer:
+    """
+    A server defined by the user.
+    """
+
+    def __init__(self, address: str):
+        self.address = address
+
+    def __str__(self):
+        return self.address
+
+    def __repr__(self):
+        return f"<CustomServer {str(self)!r}>"
+
+
+server_types = [
+    InstituteAccessServer,
+    OrganisationServer,
+    CustomServer,
+]
+
+
+# typing aliases
+ServerType = Any
+Server = Union[tuple(server_types)]
+
+
+def group_servers_by_type(servers: Iterable[Server]) -> Dict[Type, Server]:
+    groups = {server_type: [] for server_type in server_types}
+    for server in servers:
+        groups[type(server)].append(server)
+    return groups
+
+
+def is_search_match(server: Server, query: str) -> bool:
+    if hasattr(server, 'search_texts'):
+        return any(query.lower() in search_text.lower()
+                   for search_text in server.search_texts)
+    else:
+        return False
+
+
+class ServerDatabase:
+    def __init__(self):
+        # TODO load the servers from a cache
+        self.servers = []
+
+    def update(self):
+        """
+        Download the list of institute and secure internet servers,
+        and update this database.
+
+        This method must be thread-safe.
+        """
+        new_servers = []
+        server_list = list_servers(SERVER_URI)
+        organisation_list = list_organisations(ORGANISATION_URI)
+        for server_data in server_list:
+            server_type = server_data.pop('server_type')
+            if server_type == 'institute_access':
+                server = InstituteAccessServer(**server_data)
+                new_servers.append(server)
+            elif server_type == 'secure_internet':
+                server = SecureInternetServer(**server_data)
+                new_servers.append(server)
+            else:
+                raise ValueError(server_type, server_data)
+        for organisation_data in organisation_list:
+            server = OrganisationServer(**organisation_data)
+            new_servers.append(server)
+        # Atomic update of server map.
+        # TODO keep custom other servers
+        self.servers = new_servers
+
+    def all(self) -> Iterable[Server]:
+        "Return all servers."
+        return iter(self.servers)
+
+    def search(self, query: str) -> Iterable[Server]:
+        "Return all servers that match the search query."
+        if query:
+            for server in self.all():
+                if is_search_match(server, query):
+                    yield server
+        else:
+            yield from self.all()

--- a/eduvpn/state_machine.py
+++ b/eduvpn/state_machine.py
@@ -1,0 +1,179 @@
+from typing import Any, Callable, Type
+import enum
+
+
+State = Any
+Callback = Callable[[State, State], None]
+
+
+class TransitionEdge(enum.Enum):
+    """
+    The edge of a state lifetime.
+
+    The edge is `enter` when the state starts,
+    and `exit` when it ends.
+    """
+
+    enter = enum.auto()
+    exit = enum.auto()
+
+
+ENTER = TransitionEdge.enter
+EXIT = TransitionEdge.exit
+
+
+TRANSITION_CALLBACK_MARKER = '__transition_callback_for_state'
+
+def setattr_list_item(obj, attr, item):
+    try:
+        list_attr = getattr(obj, attr)
+    except AttributeError:
+        list_attr = []
+        setattr(obj, attr, list_attr)
+    list_attr.append(item)
+
+def transition_callback(state_type: Type[State]):
+    """
+    Decorator factory to mark a method as a transition callback for all transitions.
+
+    Note the argument is the base class for states of the state machine
+    to register transition events of.
+    Without this, there would be no way to know which
+    state machine this callback targets.
+    """
+    def decorator(func: Callback):
+        setattr_list_item(func, TRANSITION_CALLBACK_MARKER, (None, state_type))
+        return func
+
+    return decorator
+
+def transition_edge_callback(edge: TransitionEdge, state_type: Type[State]):
+    """
+    Decorator factory to mark a method as a transition callback
+    for specific state transition edges.
+    """
+
+    def decorator(func: Callback):
+        setattr_list_item(func, TRANSITION_CALLBACK_MARKER, (edge, state_type))
+        return func
+
+    return decorator
+
+def _find_transition_callbacks(obj: Any, base_state_type: Type[State]):
+    for attr in dir(obj):
+        callback = getattr(obj, attr)
+        try:
+            registrations = getattr(callback, TRANSITION_CALLBACK_MARKER)
+        except AttributeError:
+            pass
+        else:
+            for edge, state_type in registrations:
+                if issubclass(state_type, base_state_type):
+                    yield callback, edge, state_type
+
+
+class InvalidStateTransition(Exception):
+    def __init__(self, name: str):
+        self.name = name
+
+
+class StateMachine:
+    """
+    State machine wrapper that allows registering transition callbacks.
+    """
+
+    def __init__(self, initial_state: State):
+        self._state = initial_state
+        self._callbacks = {}
+
+    @property
+    def state(self) -> State:
+        """
+        Obtain the current state.
+
+        The state can be changed by calling `transition()`
+        with the name of a transition of the current state.
+        """
+        # The state is behind a property to prevent setting it directly.
+        return self._state
+
+    def transition(self, transition: str, *args, **kwargs):
+        """
+        Transition to a new state.
+
+        This method is *not* thread-safe,
+        all calls should be made from the same thread.
+        """
+        old_state = self._state
+        try:
+            transition_func = getattr(old_state, transition)
+        except AttributeError as e:
+            raise InvalidStateTransition(transition) from e
+        new_state = transition_func(*args, **kwargs)
+        self._call_edge_callbacks(EXIT, old_state, new_state)
+        self._state = new_state
+        self._call_generic_callbacks(old_state, new_state)
+        self._call_edge_callbacks(ENTER, old_state, new_state)
+        return new_state
+
+    def register_generic_callback(self, callback: Callback):
+        """
+        Register a callback for all transitions.
+        """
+        self._callbacks.setdefault(None, set()).add(callback)
+
+    def register_edge_callback(self, state_type: Type[State], edge: TransitionEdge, callback: Callback):
+        """
+        Register a callback for specific transition edges.
+        """
+        self._callbacks.setdefault((state_type, edge), set()).add(callback)
+
+    def connect_object_callbacks(self, obj, base_state_type: Type[State]):
+        """
+        Register all state transition callback methods decorated with
+        `@transition_callback()` and `@transition_edge_callback()` of an object.
+
+        Provide the base class of states for this state machine
+        as the second argument to filter registrations for this
+        state machine only.
+        Only method registered to a subclass of this base class
+        will be connected.
+        """
+        for callback, edge, state_type in _find_transition_callbacks(obj, base_state_type):
+            if edge is None:
+                # This callback targets all events.
+                self.register_generic_callback(callback)
+            else:
+                # This callback targets a specific state edge.
+                self.register_edge_callback(state_type, edge, callback)
+
+    def _call_generic_callbacks(self, old_state: State, new_state: State):
+        for callback in self._callbacks.get(None, []):
+            callback(old_state, new_state)
+
+    def _call_edge_callbacks(self, edge: TransitionEdge, old_state: State, new_state: State):
+        state = new_state if edge is ENTER else old_state
+        for callback in self._callbacks.get((state.__class__, edge), []):
+            callback(old_state, new_state)
+
+
+class BaseState:
+    """
+    Base class for all state machine states.
+    """
+
+    def __repr__(self):
+        fields = ','.join(f' {k}={v!r}' for k, v in self.__dict__.items())
+        return f'<{self.__class__.__name__}{fields}>'
+
+    def has_transition(self, name: str) -> bool:
+        """
+        Return True if this state defines the transition function.
+        """
+        return hasattr(self, name)
+
+    def copy(self, **fields):
+        """
+        Return a copy of this state, with some fields altered.
+        """
+        return self.__class__(**{**self.__dict__, **fields})

--- a/eduvpn/state_machine.py
+++ b/eduvpn/state_machine.py
@@ -25,6 +25,7 @@ EXIT = TransitionEdge.exit
 
 TRANSITION_CALLBACK_MARKER = '__transition_callback_for_state'
 
+
 def setattr_list_item(obj, attr, item):
     try:
         list_attr = getattr(obj, attr)
@@ -33,9 +34,11 @@ def setattr_list_item(obj, attr, item):
         setattr(obj, attr, list_attr)
     list_attr.append(item)
 
+
 def transition_callback(state_targets: StateTargets):
     """
-    Decorator factory to mark a method as a transition callback for all transitions.
+    Decorator factory to mark a method as a
+    transition callback for all transitions.
 
     Note the argument is the base class for states of the state machine
     to register transition events of.
@@ -48,12 +51,16 @@ def transition_callback(state_targets: StateTargets):
 
     def decorator(func: Callback):
         for state_type in state_targets:
-            setattr_list_item(func, TRANSITION_CALLBACK_MARKER, (None, state_type))
+            setattr_list_item(func,
+                              TRANSITION_CALLBACK_MARKER,
+                              (None, state_type))
         return func
 
     return decorator
 
-def transition_edge_callback(edge: TransitionEdge, state_targets: StateTargets):
+
+def transition_edge_callback(edge: TransitionEdge,
+                             state_targets: StateTargets):
     """
     Decorator factory to mark a method as a transition callback
     for specific state transition edges.
@@ -64,10 +71,13 @@ def transition_edge_callback(edge: TransitionEdge, state_targets: StateTargets):
 
     def decorator(func: Callback):
         for state_type in state_targets:
-            setattr_list_item(func, TRANSITION_CALLBACK_MARKER, (edge, state_type))
+            setattr_list_item(func,
+                              TRANSITION_CALLBACK_MARKER,
+                              (edge, state_type))
         return func
 
     return decorator
+
 
 def _find_transition_callbacks(obj: Any, base_state_type: Type[State]):
     for attr in dir(obj):
@@ -132,7 +142,10 @@ class StateMachine:
         """
         self._callbacks.setdefault(None, set()).add(callback)
 
-    def register_edge_callback(self, state_type: Type[State], edge: TransitionEdge, callback: Callback):
+    def register_edge_callback(self,
+                               state_type: Type[State],
+                               edge: TransitionEdge,
+                               callback: Callback):
         """
         Register a callback for specific transition edges.
         """
@@ -141,7 +154,8 @@ class StateMachine:
     def connect_object_callbacks(self, obj, base_state_type: Type[State]):
         """
         Register all state transition callback methods decorated with
-        `@transition_callback()` and `@transition_edge_callback()` of an object.
+        `@transition_callback()` and `@transition_edge_callback()`
+        of an object.
 
         Provide the base class of states for this state machine
         as the second argument to filter registrations for this
@@ -149,7 +163,8 @@ class StateMachine:
         Only method registered to a subclass of this base class
         will be connected.
         """
-        for callback, edge, state_type in _find_transition_callbacks(obj, base_state_type):
+        iterator = _find_transition_callbacks(obj, base_state_type)
+        for callback, edge, state_type in iterator:
             if edge is None:
                 # This callback targets all events.
                 self.register_generic_callback(callback)
@@ -161,7 +176,10 @@ class StateMachine:
         for callback in self._callbacks.get(None, []):
             callback(old_state, new_state)
 
-    def _call_edge_callbacks(self, edge: TransitionEdge, old_state: State, new_state: State):
+    def _call_edge_callbacks(self,
+                             edge: TransitionEdge,
+                             old_state: State,
+                             new_state: State):
         state = new_state if edge is ENTER else old_state
         for callback in self._callbacks.get((state.__class__, edge), []):
             callback(old_state, new_state)

--- a/eduvpn/state_machine.py
+++ b/eduvpn/state_machine.py
@@ -4,15 +4,6 @@ from typing import (
 import enum
 
 
-State = TypeVar('State')
-StateType = Type[State]
-Callback = Callable[[State, State], None]
-StateTargets = Union[StateType, Iterable[StateType]]
-CallbackRegistry = Dict[
-    Optional[Tuple[StateType, TransitionEdge]],
-    Set[Callback]]
-
-
 class TransitionEdge(enum.Enum):
     """
     The edge of a state lifetime.
@@ -27,6 +18,16 @@ class TransitionEdge(enum.Enum):
 
 ENTER = TransitionEdge.enter
 EXIT = TransitionEdge.exit
+
+
+# typing aliases
+State = TypeVar('State')
+StateType = Type[State]
+Callback = Callable[[State, State], None]
+StateTargets = Union[StateType, Iterable[StateType]]
+CallbackRegistry = Dict[
+    Optional[Tuple[StateType, TransitionEdge]],
+    Set[Callback]]
 
 
 TRANSITION_CALLBACK_MARKER = '__transition_callback_for_state'

--- a/eduvpn/ui/__main__.py
+++ b/eduvpn/ui/__main__.py
@@ -6,12 +6,15 @@ from argparse import ArgumentParser
 from os import geteuid
 from sys import exit, argv
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '3.0')  # noqa: E402
 from gi.repository import Gtk
 from eduvpn import __version__
 
 logger = logging.getLogger(__name__)
-log_format = format_ = '%(asctime)s - %(levelname)s - %(name)s - %(filename)s:%(lineno)d - %(message)s'
+log_format = format_ = (
+    '%(asctime)s - %(levelname)s - %(name)s'
+    ' - %(filename)s:%(lineno)d - %(message)s'
+)
 
 
 def parse_args(args: Optional[Sequence[str]]) -> int:
@@ -21,8 +24,18 @@ def parse_args(args: Optional[Sequence[str]]) -> int:
         logging_level
     """
     parser = ArgumentParser()
-    parser.add_argument('-d', '--debug', action='store_true', help="enable debug logging")
-    parser.add_argument('-v', '--version', action='store_true', help="print version and exit")
+    parser.add_argument(
+        '-d',
+        '--debug',
+        action='store_true',
+        help="enable debug logging",
+    )
+    parser.add_argument(
+        '-v',
+        '--version',
+        action='store_true',
+        help="print version and exit",
+    )
     parsed = parser.parse_args(args=args)
 
     if parsed.version:

--- a/eduvpn/ui/__main__.py
+++ b/eduvpn/ui/__main__.py
@@ -9,7 +9,6 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 from eduvpn import __version__
-from eduvpn.nm import init_dbus_system_bus
 
 logger = logging.getLogger(__name__)
 log_format = format_ = '%(asctime)s - %(levelname)s - %(name)s - %(filename)s:%(lineno)d - %(message)s'
@@ -59,7 +58,6 @@ def main_loop(args=None, lets_connect=False):
         from eduvpn.ui.ui import EduVpnGui
 
         edu_vpn_gui = EduVpnGui(lets_connect)
-        init_dbus_system_bus(edu_vpn_gui.nm_status_cb)
         edu_vpn_gui.run()
     except Exception as e:
         fatal_reason = f"Caught exception: {e}"

--- a/eduvpn/ui/search.py
+++ b/eduvpn/ui/search.py
@@ -39,7 +39,9 @@ Model = Gtk.ListStore
 @lru_cache()
 def get_server_type_model(server_type: ServerType) -> Model:
     # Model: (name: str, server: ServerType)
-    return Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_PYOBJECT)
+    return Gtk.ListStore(  # type: ignore
+        GObject.TYPE_STRING,
+        GObject.TYPE_PYOBJECT)
 
 
 def server_to_model_data(server: Server) -> list:
@@ -115,19 +117,21 @@ def disconnect_selection_handlers(builder, select_callback: Callable):
 
 def update_search_results_for_type(builder,
                                    server_type: ServerType,
-                                   servers: List[Server]):
+                                   servers: Iterable[Server]):
     """
     Update the UI with the search results
     for a single type of server.
     """
-    model = get_server_type_model(server_type)
+    model = get_server_type_model(server_type)  # type: ignore
     # Remove the old search results.
-    model.clear()
+    model.clear()  # type: ignore
     # Add the new search results.
     for server in servers:
-        model.append(server_to_model_data(server))
+        model_data = server_to_model_data(server)
+        model.append(model_data)  # type: ignore
     # Update the UI.
-    show_server_type_tree(builder, server_type, show=len(model) > 0)
+    model_has_results = len(model) > 0  # type: ignore
+    show_server_type_tree(builder, server_type, show=model_has_results)
 
 
 def update_results(builder, servers: Optional[Iterable[Server]]):

--- a/eduvpn/ui/search.py
+++ b/eduvpn/ui/search.py
@@ -2,8 +2,8 @@ from typing import Optional, List, Dict, Iterable, Callable
 from functools import lru_cache
 from gi.repository import Gtk, GObject
 from eduvpn.server import (
-    ServerType, Server, InstituteAccessServer, OrganisationServer, CustomServer,
-    ServerDatabase, group_servers_by_type)
+    ServerType, Server, InstituteAccessServer, OrganisationServer,
+    CustomServer, ServerDatabase, group_servers_by_type)
 from .utils import show_ui_component
 
 
@@ -35,10 +35,12 @@ gtk_search_components = [
 
 Model = Gtk.ListStore
 
+
 @lru_cache()
 def get_server_type_model(server_type: ServerType) -> Model:
     # Model: (name: str, server: ServerType)
     return Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_PYOBJECT)
+
 
 def server_to_model_data(server: Server) -> list:
     return [str(server), server]
@@ -51,18 +53,23 @@ def show_search_components(builder, show: bool):
     for name in gtk_search_components:
         show_ui_component(builder, name, show)
 
+
 def show_search_resuls(builder, show: bool):
     """
     Set the visibility of the tree of the search result component in the UI.
     """
     show_ui_component(builder, 'findYourInstituteScrolledWindow', show)
 
+
 def show_server_type_tree(builder, server_type: ServerType, show: bool):
     """
     Set the visibility of the tree of result for a server type.
     """
-    show_ui_component(builder, location_type_tree_component[server_type], show)
-    show_ui_component(builder, location_type_header_component[server_type], show)
+    tree_component_name = location_type_tree_component[server_type]
+    show_ui_component(builder, tree_component_name, show)
+    header_component_name = location_type_header_component[server_type]
+    show_ui_component(builder, header_component_name, show)
+
 
 def init_server_search(builder):
     "Initialize the search page components."
@@ -70,13 +77,15 @@ def init_server_search(builder):
     text_cell = Gtk.CellRendererText()
     text_cell.set_property("size-points", 14)
     for server_type in location_type_tree_component:
-        tree_view = builder.get_object(location_type_tree_component[server_type])
+        component_name = location_type_tree_component[server_type]
+        tree_view = builder.get_object(component_name)
         column = Gtk.TreeViewColumn(None, text_cell, text=0)
         if len(tree_view.get_columns()) == 0:
             # Only add this column once.
             tree_view.append_column(column)
         model = get_server_type_model(server_type)
         tree_view.set_model(model)
+
 
 def exit_server_search(builder):
     "Hide the search page components."
@@ -85,21 +94,28 @@ def exit_server_search(builder):
         show_server_type_tree(builder, server_type, False)
     show_search_resuls(builder, False)
 
+
 def connect_selection_handlers(builder, select_callback: Callable):
     "Connect the selection callback handlers for each server type."
     for server_type in location_type_tree_component:
-        tree_view = builder.get_object(location_type_tree_component[server_type])
+        component_name = location_type_tree_component[server_type]
+        tree_view = builder.get_object(component_name)
         selection = tree_view.get_selection()
         selection.connect("changed", select_callback)
+
 
 def disconnect_selection_handlers(builder, select_callback: Callable):
     "Disconnect the selection callback handlers for each server type."
     for server_type in location_type_tree_component:
-        tree_view = builder.get_object(location_type_tree_component[server_type])
+        component_name = location_type_tree_component[server_type]
+        tree_view = builder.get_object(component_name)
         selection = tree_view.get_selection()
         selection.disconnect_by_func(select_callback)
 
-def update_search_results_for_type(builder, server_type: ServerType, servers: List[Server]):
+
+def update_search_results_for_type(builder,
+                                   server_type: ServerType,
+                                   servers: List[Server]):
     """
     Update the UI with the search results
     for a single type of server.
@@ -113,6 +129,7 @@ def update_search_results_for_type(builder, server_type: ServerType, servers: Li
     # Update the UI.
     show_server_type_tree(builder, server_type, show=len(model) > 0)
 
+
 def update_results(builder, servers: Optional[Iterable[Server]]):
     """
     Update the UI with the search results.
@@ -122,5 +139,9 @@ def update_results(builder, servers: Optional[Iterable[Server]]):
         return
     server_map = group_servers_by_type(servers)
     for server_type in location_type_tree_component:
-        update_search_results_for_type(builder, server_type, server_map.get(server_type, []))
+        update_search_results_for_type(
+            builder,
+            server_type,
+            server_map.get(server_type, []),
+        )
     show_search_resuls(builder, True)

--- a/eduvpn/ui/search.py
+++ b/eduvpn/ui/search.py
@@ -1,0 +1,126 @@
+from typing import Optional, List, Dict, Iterable, Callable
+from functools import lru_cache
+from gi.repository import Gtk, GObject
+from eduvpn.server import (
+    ServerType, Server, InstituteAccessServer, OrganisationServer, CustomServer,
+    ServerDatabase, group_servers_by_type)
+from .utils import show_ui_component
+
+
+location_type_tree_component = {
+    InstituteAccessServer: 'instituteTreeView',
+    OrganisationServer: 'secureInternetTreeView',
+    CustomServer: 'otherServersTreeView',
+}
+
+location_type_header_component = {
+    InstituteAccessServer: 'instituteAccessHeader',
+    OrganisationServer: 'secureInternetHeader',
+    CustomServer: 'otherServersHeader',
+}
+
+gtk_search_components = [
+    # These are the components that need
+    # to be shown on all search pages.
+    'findYourInstitutePage',
+    'instituteTreeView',
+    'secureInternetTreeView',
+    'otherServersTreeView',
+    'findYourInstituteSpacer',
+    'findYourInstituteImage',
+    'findYourInstituteLabel',
+    'findYourInstituteSearch',
+]
+
+
+Model = Gtk.ListStore
+
+@lru_cache()
+def get_server_type_model(server_type: ServerType) -> Model:
+    # Model: (name: str, server: ServerType)
+    return Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_PYOBJECT)
+
+def server_to_model_data(server: Server) -> list:
+    return [str(server), server]
+
+
+def show_search_components(builder, show: bool):
+    """
+    Set the visibility of essential search related components.
+    """
+    for name in gtk_search_components:
+        show_ui_component(builder, name, show)
+
+def show_search_resuls(builder, show: bool):
+    """
+    Set the visibility of the tree of the search result component in the UI.
+    """
+    show_ui_component(builder, 'findYourInstituteScrolledWindow', show)
+
+def show_server_type_tree(builder, server_type: ServerType, show: bool):
+    """
+    Set the visibility of the tree of result for a server type.
+    """
+    show_ui_component(builder, location_type_tree_component[server_type], show)
+    show_ui_component(builder, location_type_header_component[server_type], show)
+
+def init_server_search(builder):
+    "Initialize the search page components."
+    show_search_components(builder, True)
+    text_cell = Gtk.CellRendererText()
+    text_cell.set_property("size-points", 14)
+    for server_type in location_type_tree_component:
+        tree_view = builder.get_object(location_type_tree_component[server_type])
+        column = Gtk.TreeViewColumn(None, text_cell, text=0)
+        if len(tree_view.get_columns()) == 0:
+            # Only add this column once.
+            tree_view.append_column(column)
+        model = get_server_type_model(server_type)
+        tree_view.set_model(model)
+
+def exit_server_search(builder):
+    "Hide the search page components."
+    show_search_components(builder, False)
+    for server_type in location_type_tree_component:
+        show_server_type_tree(builder, server_type, False)
+    show_search_resuls(builder, False)
+
+def connect_selection_handlers(builder, select_callback: Callable):
+    "Connect the selection callback handlers for each server type."
+    for server_type in location_type_tree_component:
+        tree_view = builder.get_object(location_type_tree_component[server_type])
+        selection = tree_view.get_selection()
+        selection.connect("changed", select_callback)
+
+def disconnect_selection_handlers(builder, select_callback: Callable):
+    "Disconnect the selection callback handlers for each server type."
+    for server_type in location_type_tree_component:
+        tree_view = builder.get_object(location_type_tree_component[server_type])
+        selection = tree_view.get_selection()
+        selection.disconnect_by_func(select_callback)
+
+def update_search_results_for_type(builder, server_type: ServerType, servers: List[Server]):
+    """
+    Update the UI with the search results
+    for a single type of server.
+    """
+    model = get_server_type_model(server_type)
+    # Remove the old search results.
+    model.clear()
+    # Add the new search results.
+    for server in servers:
+        model.append(server_to_model_data(server))
+    # Update the UI.
+    show_server_type_tree(builder, server_type, show=len(model) > 0)
+
+def update_results(builder, servers: Optional[Iterable[Server]]):
+    """
+    Update the UI with the search results.
+    """
+    if servers is None:
+        show_search_resuls(builder, False)
+        return
+    server_map = group_servers_by_type(servers)
+    for server_type in location_type_tree_component:
+        update_search_results_for_type(builder, server_type, server_map.get(server_type, []))
+    show_search_resuls(builder, True)

--- a/eduvpn/ui/ui.py
+++ b/eduvpn/ui/ui.py
@@ -9,8 +9,8 @@ import webbrowser
 import logging
 
 import gi
-gi.require_version('Gtk', '3.0')
-gi.require_version('NM', '1.0')
+gi.require_version('Gtk', '3.0')  # noqa: E402
+gi.require_version('NM', '1.0')  # noqa: E402
 from gi.repository import Gtk
 
 from requests_oauthlib import OAuth2Session
@@ -22,7 +22,8 @@ from .. import network
 from .. import interface
 from ..server import CustomServer
 from ..app import Application
-from ..state_machine import ENTER, EXIT, transition_callback, transition_edge_callback
+from ..state_machine import (
+    ENTER, EXIT, transition_callback, transition_edge_callback)
 from ..utils import get_prefix, thread_helper, run_in_main_gtk_thread
 from . import search
 from .utils import show_ui_component
@@ -30,7 +31,7 @@ from .utils import show_ui_component
 
 logger = logging.getLogger(__name__)
 
-builder_files: List[str] = ['mainwindow.ui']
+builder_files = ['mainwindow.ui']
 
 variable_objects = [
     'backButton',
@@ -94,7 +95,7 @@ class EduVpnGui:
         for b in builder_files:
             p = os.path.join(prefix, 'share/eduvpn/builder', b)
             if not os.access(p, os.R_OK):
-                logger.error(f"Can't find {p}! That is quite an important file.")
+                logger.error(f"Can't find builder file {p}!")
                 raise Exception
             self.builder.add_from_file(p)
 
@@ -105,9 +106,12 @@ class EduVpnGui:
             "on_back_button_released": self.on_back_button_released,
             "on_search_changed": self.on_search_changed,
             "on_activate_changed": self.on_activate_changed,
-            "on_add_other_server_button_clicked": self.on_add_other_server_button_clicked,
-            "on_cancel_browser_button_clicked": self.on_cancel_oauth_setup_button_clicked,
-            "on_connection_switch_state_set": self.on_connection_switch_state_set
+            "on_add_other_server_button_clicked":
+                self.on_add_other_server_button_clicked,
+            "on_cancel_browser_button_clicked":
+                self.on_cancel_oauth_setup_button_clicked,
+            "on_connection_switch_state_set":
+                self.on_connection_switch_state_set
         }
         self.builder.connect_signals(handlers)
 
@@ -116,17 +120,6 @@ class EduVpnGui:
             self.show_component(name, False)
 
         self.app = Application(run_in_main_gtk_thread)
-
-
-        # TODO x
-        from eduvpn import nm
-        print('-' * 20)
-        client = nm.get_client()
-        x1 = nm.connection_status(client)
-        print(x1)
-        x2 = nm.get_vpn_status(client)
-        print(x2)
-        print('-' * 20)
 
     def run(self):
         logger.info("starting ui")
@@ -170,16 +163,19 @@ class EduVpnGui:
     def enter_search(self, old_state, new_state):
         if not isinstance(old_state, interface.configure_server_states):
             search.init_server_search(self.builder)
-            search.connect_selection_handlers(self.builder, self.on_select_server)
+            search.connect_selection_handlers(
+                self.builder, self.on_select_server)
 
     @transition_edge_callback(EXIT, interface.configure_server_states)
     def exit_search(self, old_state, new_state):
         if not isinstance(new_state, interface.configure_server_states):
             search.exit_server_search(self.builder)
-            search.disconnect_selection_handlers(self.builder, self.on_select_server)
+            search.disconnect_selection_handlers(
+                self.builder, self.on_select_server)
             self.set_search_text('')
 
-    @transition_edge_callback(ENTER, interface.PendingConfigurePredefinedServer)
+    @transition_edge_callback(
+        ENTER, interface.PendingConfigurePredefinedServer)
     def enter_PendingConfigurePredefinedServer(self, old_state, new_state):
         search.update_results(self.builder, [])
         if not isinstance(old_state, interface.configure_server_states):
@@ -202,10 +198,18 @@ class EduVpnGui:
         self.show_component('openBrowserPage', True)
 
         def fetch_token():
-            url, oauth_session, token_endpoint, auth_endpoint = actions.fetch_token(new_state.server.oauth_login_url)
-            # TODO handle error: self.app.interface_transition('oauth_setup_failure', error="unknown error")
-            # TODO handle cancel: self.app.interface_transition('oauth_setup_cancel')
-            logger.debug(f'got new oauth token: {url!r} {oauth_session!r} {token_endpoint!r} {auth_endpoint!r}')
+            url, oauth_session, token_endpoint, auth_endpoint = \
+                actions.fetch_token(new_state.server.oauth_login_url)
+            # TODO handle error:
+            #     self.app.interface_transition(
+            #         'oauth_setup_failure', error="unknown error")
+            # TODO handle cancel:
+            #     self.app.interface_transition('oauth_setup_cancel')
+            logger.debug(
+                f'got new oauth token: '
+                f'{url!r} {oauth_session!r} '
+                f'{token_endpoint!r} {auth_endpoint!r}'
+            )
             self.app.interface_transition('oauth_setup_success')
 
         # TODO stop thread when state changes (eg. click on settings)
@@ -252,10 +256,13 @@ class EduVpnGui:
         query = self.builder.get_object('findYourInstituteSearch').get_text()
         logger.debug(f"entered search query: {query}")
         if self.lets_connect or query.count('.') >= 2:
-            # Anything with two periods is interpreted as a custom server address.
-            self.app.interface_transition('enter_custom_address', address=query)
+            # Anything with two periods is interpreted
+            # as a custom server address.
+            self.app.interface_transition(
+                'enter_custom_address', address=query)
         else:
-            self.app.interface_transition('enter_search_query', search_query=query)
+            self.app.interface_transition(
+                'enter_search_query', search_query=query)
 
     def on_activate_changed(self, _=None):
         logger.debug("on_activate_changed")

--- a/eduvpn/ui/ui.py
+++ b/eduvpn/ui/ui.py
@@ -163,17 +163,13 @@ class EduVpnGui:
     def exit_ConfigureSettings(self, old_state, new_state):
         self.show_component('settingsPage', False)
 
-    @transition_edge_callback(ENTER, interface.PendingConfigurePredefinedServer)
-    @transition_edge_callback(ENTER, interface.ConfigurePredefinedServer)
-    @transition_edge_callback(ENTER, interface.ConfigureCustomServer)
+    @transition_edge_callback(ENTER, interface.configure_server_states)
     def enter_search(self, old_state, new_state):
         if not isinstance(old_state, interface.configure_server_states):
             search.init_server_search(self.builder)
             search.connect_selection_handlers(self.builder, self.on_select_server)
 
-    @transition_edge_callback(EXIT, interface.PendingConfigurePredefinedServer)
-    @transition_edge_callback(EXIT, interface.ConfigurePredefinedServer)
-    @transition_edge_callback(EXIT, interface.ConfigureCustomServer)
+    @transition_edge_callback(EXIT, interface.configure_server_states)
     def exit_search(self, old_state, new_state):
         if not isinstance(new_state, interface.configure_server_states):
             search.exit_server_search(self.builder)

--- a/eduvpn/ui/ui.py
+++ b/eduvpn/ui/ui.py
@@ -143,6 +143,9 @@ class EduVpnGui:
         self.show_component('backButton', show)
         self.show_component('backButtonEventBox', show)
 
+    def set_search_text(self, text: str):
+        self.builder.get_object('findYourInstituteSearch').set_text(text)
+
     # network state transition callbacks
 
     # TODO
@@ -174,25 +177,25 @@ class EduVpnGui:
         if not isinstance(new_state, interface.configure_server_states):
             search.exit_server_search(self.builder)
             search.disconnect_selection_handlers(self.builder, self.on_select_server)
-            self.builder.get_object('findYourInstituteSearch').set_text('')
+            self.set_search_text('')
 
     @transition_edge_callback(ENTER, interface.PendingConfigurePredefinedServer)
     def enter_PendingConfigurePredefinedServer(self, old_state, new_state):
         search.update_results(self.builder, [])
         if not isinstance(old_state, interface.configure_server_states):
-            self.builder.get_object('findYourInstituteSearch').set_text(new_state.search_query)
+            self.set_search_text(new_state.search_query)
 
     @transition_edge_callback(ENTER, interface.ConfigurePredefinedServer)
     def enter_ConfigurePredefinedServer(self, old_state, new_state):
         search.update_results(self.builder, new_state.results)
         if not isinstance(old_state, interface.configure_server_states):
-            self.builder.get_object('findYourInstituteSearch').set_text(new_state.search_query)
+            self.set_search_text(new_state.search_query)
 
     @transition_edge_callback(ENTER, interface.ConfigureCustomServer)
     def enter_ConfigureCustomServer(self, old_state, new_state):
         search.update_results(self.builder, [CustomServer(new_state.address)])
         if not isinstance(old_state, interface.configure_server_states):
-            self.builder.get_object('findYourInstituteSearch').set_text(new_state.address)
+            self.set_search_text(new_state.address)
 
     @transition_edge_callback(ENTER, interface.OAuthSetup)
     def enter_OAuthSetup(self, old_state, new_state):

--- a/eduvpn/ui/ui.py
+++ b/eduvpn/ui/ui.py
@@ -115,7 +115,7 @@ class EduVpnGui:
         for name in variable_objects:
             self.show_component(name, False)
 
-        self.app = Application()
+        self.app = Application(run_in_main_gtk_thread)
 
 
         # TODO x
@@ -132,7 +132,7 @@ class EduVpnGui:
         logger.info("starting ui")
         self.show_component('applicationWindow', True)
         self.app.connect_state_transition_callbacks(self)
-        self.app.initialize(run_in_main_gtk_thread)
+        self.app.initialize()
 
     # ui functions
 

--- a/eduvpn/ui/ui.py
+++ b/eduvpn/ui/ui.py
@@ -3,7 +3,7 @@
 # Copyright: 2017-2020, The Commons Conservancy eduVPN Programme
 # SPDX-License-Identifier: GPL-3.0+
 
-from typing import List
+from typing import Any, List
 import os
 import webbrowser
 import logging
@@ -89,7 +89,7 @@ class EduVpnGui:
         """
         self.lets_connect = lets_connect
 
-        self.builder = Gtk.Builder()
+        self.builder: Any = Gtk.Builder()
 
         prefix = get_prefix()
         for b in builder_files:

--- a/eduvpn/ui/ui.py
+++ b/eduvpn/ui/ui.py
@@ -163,31 +163,39 @@ class EduVpnGui:
     def exit_ConfigureSettings(self, old_state, new_state):
         self.show_component('settingsPage', False)
 
+    @transition_edge_callback(ENTER, interface.PendingConfigurePredefinedServer)
     @transition_edge_callback(ENTER, interface.ConfigurePredefinedServer)
     @transition_edge_callback(ENTER, interface.ConfigureCustomServer)
     def enter_search(self, old_state, new_state):
-        if not isinstance(old_state, (interface.ConfigureCustomServer, interface.ConfigurePredefinedServer)):
+        if not isinstance(old_state, interface.configure_server_states):
             search.init_server_search(self.builder)
             search.connect_selection_handlers(self.builder, self.on_select_server)
 
+    @transition_edge_callback(EXIT, interface.PendingConfigurePredefinedServer)
     @transition_edge_callback(EXIT, interface.ConfigurePredefinedServer)
     @transition_edge_callback(EXIT, interface.ConfigureCustomServer)
     def exit_search(self, old_state, new_state):
-        if not isinstance(new_state, (interface.ConfigureCustomServer, interface.ConfigurePredefinedServer)):
+        if not isinstance(new_state, interface.configure_server_states):
             search.exit_server_search(self.builder)
             search.disconnect_selection_handlers(self.builder, self.on_select_server)
             self.builder.get_object('findYourInstituteSearch').set_text('')
 
+    @transition_edge_callback(ENTER, interface.PendingConfigurePredefinedServer)
+    def enter_PendingConfigurePredefinedServer(self, old_state, new_state):
+        search.update_results(self.builder, [])
+        if not isinstance(old_state, interface.configure_server_states):
+            self.builder.get_object('findYourInstituteSearch').set_text(new_state.search_query)
+
     @transition_edge_callback(ENTER, interface.ConfigurePredefinedServer)
     def enter_ConfigurePredefinedServer(self, old_state, new_state):
         search.update_results(self.builder, new_state.results)
-        if not isinstance(old_state, (interface.ConfigureCustomServer, interface.ConfigurePredefinedServer)):
+        if not isinstance(old_state, interface.configure_server_states):
             self.builder.get_object('findYourInstituteSearch').set_text(new_state.search_query)
 
     @transition_edge_callback(ENTER, interface.ConfigureCustomServer)
     def enter_ConfigureCustomServer(self, old_state, new_state):
         search.update_results(self.builder, [CustomServer(new_state.address)])
-        if not isinstance(old_state, (interface.ConfigureCustomServer, interface.ConfigurePredefinedServer)):
+        if not isinstance(old_state, interface.configure_server_states):
             self.builder.get_object('findYourInstituteSearch').set_text(new_state.address)
 
     @transition_edge_callback(ENTER, interface.OAuthSetup)

--- a/eduvpn/ui/ui.py
+++ b/eduvpn/ui/ui.py
@@ -3,58 +3,96 @@
 # Copyright: 2017-2020, The Commons Conservancy eduVPN Programme
 # SPDX-License-Identifier: GPL-3.0+
 
+from typing import List
 import os
-import re
 import webbrowser
-from logging import getLogger
-from pathlib import Path
-from typing import Any, List
+import logging
 
 import gi
-
 gi.require_version('Gtk', '3.0')
 gi.require_version('NM', '1.0')
-from gi.repository import NM  # type: ignore
-from gi.repository import Gtk, GObject, GLib, GdkPixbuf
+from gi.repository import Gtk
+
 from requests_oauthlib import OAuth2Session
 from oauthlib.oauth2.rfc6749.tokens import OAuth2Token
 
-from eduvpn.utils import get_prefix, thread_helper
-from eduvpn.storage import get_uuid, get_all_metadatas
-from eduvpn.i18n import extract_translation, retrieve_country_name
-from eduvpn.nm import get_client, save_connection, nm_available, activate_connection, deactivate_connection, \
-    init_dbus_system_bus
-from eduvpn.oauth2 import get_oauth
-from eduvpn.remote import get_info, create_keypair, get_config, list_profiles
-from eduvpn.settings import CLIENT_ID, FLAG_PREFIX, IMAGE_PREFIX, HELP_URL, LETS_CONNECT_LOGO, LETS_CONNECT_NAME, \
-    LETS_CONNECT_ICON, SERVER_ILLUSTRATION
-from eduvpn.storage import set_metadata, get_current_metadata, set_auth_url, write_config, get_auth_url
-from eduvpn.ui.backend import BackendData
-from eduvpn.ui.vpn_connection import VpnConnection
+from ..settings import HELP_URL
+from .. import actions
+from .. import network
+from .. import interface
+from ..server import CustomServer
+from ..app import Application
+from ..state_machine import ENTER, EXIT, transition_callback, transition_edge_callback
+from ..utils import get_prefix, thread_helper, run_in_main_gtk_thread
+from . import search
+from .utils import show_ui_component
 
-logger = getLogger(__name__)
+
+logger = logging.getLogger(__name__)
 
 builder_files: List[str] = ['mainwindow.ui']
 
+variable_objects = [
+    'backButton',
+    # 'backButtonEventBox',
+    'findYourInstitutePage',
+    'instituteTreeView',
+    'secureInternetTreeView',
+    'otherServersTreeView',
+    'findYourInstituteSpacer',
+    'findYourInstituteImage',
+    'findYourInstituteLabel',
+    'addOtherServerRow',
+    'addOtherServerButton',
+    'findYourInstituteScrolledWindow',
+    'instituteAccessHeader',
+    'secureInternetHeader',
+    'otherServersHeader',
+    'findYourInstituteSearch',
+    'chooseProfilePage',
+    'profileTreeView',
+    'chooseLocationPage',
+    'locationTreeView',
+    'openBrowserPage',
+    'connectionPage',
+    'serverLabel',
+    'serverImage',
+    'supportLabel',
+    'connectionStatusImage',
+    'connectionStatusLabel',
+    'connectionSubStatus',
+    'profilesSubPage',
+    'currentConnectionSubPage',
+    'connectionSubPage',
+    'connectionInfoTopRow',
+    'connectionInfoGrid',
+    'durationValueLabel',
+    'downloadedValueLabel',
+    'uploadedValueLabel',
+    'ipv4ValueLabel',
+    'ipv6ValueLabel',
+    'connectionInfoBottomRow',
+    'connectionSwitch',
+    'settingsPage',
+    'messagePage',
+    'messageLabel',
+    'messageText',
+    'messageButton',
+]
+
 
 class EduVpnGui:
-
-    def __init__(self, lets_connect: bool) -> None:
+    def __init__(self, lets_connect: bool):
         """
         Initialize all data structures needed in the GUI
         """
-        self.lets_connect: bool = lets_connect
+        self.lets_connect = lets_connect
 
-        self.prefix: str = get_prefix()
-        self.builder: Any = Gtk.Builder()
+        self.builder = Gtk.Builder()
 
-        self.client: Any = get_client()
-
-        self.auto_connect: bool = False
-        self.act_on_switch: bool = False
-
+        prefix = get_prefix()
         for b in builder_files:
-            p = os.path.join(self.prefix, 'share/eduvpn/builder', b)
+            p = os.path.join(prefix, 'share/eduvpn/builder', b)
             if not os.access(p, os.R_OK):
                 logger.error(f"Can't find {p}! That is quite an important file.")
                 raise Exception
@@ -68,918 +106,162 @@ class EduVpnGui:
             "on_search_changed": self.on_search_changed,
             "on_activate_changed": self.on_activate_changed,
             "on_add_other_server_button_clicked": self.on_add_other_server_button_clicked,
-            "on_cancel_browser_button_clicked": self.on_cancel_browser_button_clicked,
+            "on_cancel_browser_button_clicked": self.on_cancel_oauth_setup_button_clicked,
             "on_connection_switch_state_set": self.on_connection_switch_state_set
         }
-
         self.builder.connect_signals(handlers)
-        self.selection_handlers_connected = False
-        self.window = self.builder.get_object('applicationWindow')
-        self.logo_image = self.builder.get_object('logoImage')
 
-        self.back_button = self.builder.get_object('backButton')
-        self.back_button_event_box = self.builder.get_object('backButtonEventBox')
+        # Hide all objects that are visible on only some pages.
+        for name in variable_objects:
+            self.show_component(name, False)
 
-        self.find_your_institute_page = self.builder.get_object('findYourInstitutePage')
-        self.institute_tree_view = self.builder.get_object('instituteTreeView')
-        self.secure_internet_tree_view = self.builder.get_object('secureInternetTreeView')
-        self.other_servers_tree_view = self.builder.get_object('otherServersTreeView')
-        self.find_your_institute_spacer = self.builder.get_object('findYourInstituteSpacer')
-        self.find_your_institute_image = self.builder.get_object('findYourInstituteImage')
-        self.find_your_institute_label = self.builder.get_object('findYourInstituteLabel')
+        self.app = Application()
 
-        self.add_other_server_row = self.builder.get_object('addOtherServerRow')
-        self.add_other_server_button = self.builder.get_object('addOtherServerButton')
-        self.find_your_institute_window = self.builder.get_object('findYourInstituteScrolledWindow')
 
-        self.institute_access_header = self.builder.get_object('instituteAccessHeader')
-        self.secure_internet_header = self.builder.get_object('secureInternetHeader')
-        self.other_servers_header = self.builder.get_object('otherServersHeader')
-        self.find_your_institute_search = self.builder.get_object('findYourInstituteSearch')
+        # TODO x
+        from eduvpn import nm
+        print('-' * 20)
+        client = nm.get_client()
+        x1 = nm.connection_status(client)
+        print(x1)
+        x2 = nm.get_vpn_status(client)
+        print(x2)
+        print('-' * 20)
 
-        self.choose_profile_page = self.builder.get_object('chooseProfilePage')
-        self.profile_tree_view = self.builder.get_object('profileTreeView')
+    def run(self):
+        logger.info("starting ui")
+        self.show_component('applicationWindow', True)
+        self.app.connect_state_transition_callbacks(self)
+        self.app.initialize(run_in_main_gtk_thread)
 
-        self.choose_location_page = self.builder.get_object('chooseLocationPage')
-        self.location_tree_view = self.builder.get_object('locationTreeView')
+    # ui functions
 
-        self.open_browser_page = self.builder.get_object('openBrowserPage')
+    def show_component(self, component: str, show: bool):
+        show_ui_component(self.builder, component, show)
 
-        self.connection_page = self.builder.get_object('connectionPage')
-        self.server_label = self.builder.get_object('serverLabel')
-        self.server_image = self.builder.get_object('serverImage')
-        self.support_label = self.builder.get_object('supportLabel')
-        self.connection_status_image = self.builder.get_object('connectionStatusImage')
-        self.connection_status_label = self.builder.get_object('connectionStatusLabel')
-        self.connection_sub_status = self.builder.get_object('connectionSubStatus')
-        self.profiles_sub_page = self.builder.get_object('profilesSubPage')
-        self.current_connection_sub_page = self.builder.get_object('currentConnectionSubPage')
-        self.connection_sub_page = self.builder.get_object('connectionSubPage')
-        self.connection_info_top_row = self.builder.get_object('connectionInfoTopRow')
-        self.connection_info_grid = self.builder.get_object('connectionInfoGrid')
-        self.duration_value_label = self.builder.get_object('durationValueLabel')
-        self.downloaded_value_label = self.builder.get_object('downloadedValueLabel')
-        self.uploaded_value_label = self.builder.get_object('uploadedValueLabel')
-        self.ipv4_value_label = self.builder.get_object('ipv4ValueLabel')
-        self.ipv6_value_label = self.builder.get_object('ipv6ValueLabel')
-        self.connection_info_bottom_row = self.builder.get_object('connectionInfoBottomRow')
-        self.connection_switch = self.builder.get_object('connectionSwitch')
+    def show_back_button(self, show: bool):
+        self.show_component('backButton', show)
+        self.show_component('backButtonEventBox', show)
 
-        self.settings_page = self.builder.get_object('settingsPage')
+    # network state transition callbacks
 
-        self.message_page = self.builder.get_object('messagePage')
-        self.message_label = self.builder.get_object('messageLabel')
-        self.message_text = self.builder.get_object('messageText')
-        self.message_button = self.builder.get_object('messageButton')
+    # TODO
 
-        self.institute_list_model = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_INT)  # type: ignore
-        self.secure_internet_list_model = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_INT)  # type: ignore
-        self.other_servers_list_model = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_INT)  # type: ignore
-        self.profiles_list_model = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_INT)  # type: ignore
-        self.locations_list_model = Gtk.ListStore(GObject.TYPE_STRING, GdkPixbuf.Pixbuf,  # type: ignore
-                                                  GObject.TYPE_INT)  # type: ignore
+    # interface state transition callbacks
 
-        self.connections: List[VpnConnection] = []
-        self.select_existing_connection = False
+    @transition_callback(interface.InterfaceState)
+    def default_transition_callback(self, old_state, new_state):
+        # Only show the 'go back' button if
+        # the corresponding transition is available.
+        self.show_back_button(new_state.has_transition('go_back'))
 
-        try:
-            self.data = BackendData(lets_connect=lets_connect)
-        except Exception as e:
-            msg = f"Got exception {e} initializing backend data"
-            logger.error(msg)
-        else:
-            init_dbus_system_bus(self.nm_status_cb)
+    @transition_edge_callback(ENTER, interface.ConfigureSettings)
+    def enter_ConfigureSettings(self, old_state, new_state):
+        self.show_component('settingsPage', True)
 
-            self.init_search_list()
-            self.show_back_button(False)
-            self.read_connections()
-            if self.lets_connect:
-                self.logo_image.set_from_file(LETS_CONNECT_LOGO)
-                self.find_your_institute_image.set_from_file(SERVER_ILLUSTRATION)
-                self.find_your_institute_label.set_text("Server address")
-                self.add_other_server_button.set_label("Add server")
-                self.add_other_server_row.show()
-                self.window.set_title(LETS_CONNECT_NAME)
-                self.window.set_icon_from_file(LETS_CONNECT_ICON)
-            else:
-                self.add_other_server_row.hide()
+    @transition_edge_callback(EXIT, interface.ConfigureSettings)
+    def exit_ConfigureSettings(self, old_state, new_state):
+        self.show_component('settingsPage', False)
 
-    def read_connections(self):
-        """
-        Read all vpn connections from storage
-        """
-        logger.debug("read_connections")
-        self.connections = []
-        for auth_url, props in get_all_metadatas().items():
-            vpn_connection = VpnConnection()
-            vpn_connection.auth_url = auth_url
-            vpn_connection.api_url = props['api_url']
-            vpn_connection.server_name = props['display_name']
-            vpn_connection.support_contact = props['support_contact']
-            vpn_connection.profile_id = props['profile_id']
-            vpn_connection.token_endpoint = props['token_endpoint']
-            vpn_connection.authorization_endpoint = props['authorization_endpoint']
-            vpn_connection.token = OAuth2Token(props['token'])
-            vpn_connection.type = props['con_type']
-            vpn_connection.server_image = props['country_id']
-            self.connections.append(vpn_connection)
+    @transition_edge_callback(ENTER, interface.ConfigurePredefinedServer)
+    @transition_edge_callback(ENTER, interface.ConfigureCustomServer)
+    def enter_search(self, old_state, new_state):
+        if not isinstance(old_state, (interface.ConfigureCustomServer, interface.ConfigurePredefinedServer)):
+            search.init_server_search(self.builder)
+            search.connect_selection_handlers(self.builder, self.on_select_server)
 
-    def nm_status_cb(self,
-                     state_code: NM.VpnConnectionState = NM.VpnConnectionState.UNKNOWN,
-                     reason_code: NM.VpnConnectionStateReason = NM.VpnConnectionStateReason.UNKNOWN):
-        """
-        This method is called when a DBUS VPN state change event is received.
+    @transition_edge_callback(EXIT, interface.ConfigurePredefinedServer)
+    @transition_edge_callback(EXIT, interface.ConfigureCustomServer)
+    def exit_search(self, old_state, new_state):
+        if not isinstance(new_state, (interface.ConfigureCustomServer, interface.ConfigurePredefinedServer)):
+            search.exit_server_search(self.builder)
+            search.disconnect_selection_handlers(self.builder, self.on_select_server)
+            self.builder.get_object('findYourInstituteSearch').set_text('')
 
-        Handles auto connect when that is enabled.
-        """
-        if type(state_code) != NM.VpnConnectionState:
-            state_code = NM.VpnConnectionState(state_code)
+    @transition_edge_callback(ENTER, interface.ConfigurePredefinedServer)
+    def enter_ConfigurePredefinedServer(self, old_state, new_state):
+        search.update_results(self.builder, new_state.results)
+        if not isinstance(old_state, (interface.ConfigureCustomServer, interface.ConfigurePredefinedServer)):
+            self.builder.get_object('findYourInstituteSearch').set_text(new_state.search_query)
 
-        if type(reason_code) != NM.VpnConnectionStateReason:
-            reason_code = NM.VpnConnectionStateReason(state_code)
+    @transition_edge_callback(ENTER, interface.ConfigureCustomServer)
+    def enter_ConfigureCustomServer(self, old_state, new_state):
+        search.update_results(self.builder, [CustomServer(new_state.address)])
+        if not isinstance(old_state, (interface.ConfigureCustomServer, interface.ConfigurePredefinedServer)):
+            self.builder.get_object('findYourInstituteSearch').set_text(new_state.address)
 
-        self.update_connection_state(state_code)
-        logger.debug(f"nm_status_cb state: {state_code.value_name}, reason: {reason_code.value_name}")
-        self.connection_switch.set_state(state_code == NM.VpnConnectionState.ACTIVATED)
-        if self.auto_connect:
-            if state_code == NM.VpnConnectionState.DISCONNECTED:
-                self.activate_connection()
-            elif state_code == NM.VpnConnectionState.ACTIVATED:
-                self.auto_connect = False
-                self.act_on_switch = True
-                self.data.vpn_connection.server_name = self.data.new_server_name
-                self.data.vpn_connection.server_image = self.data.new_server_image
-                self.data.vpn_connection.support_contact = self.data.new_support_contact
-                self.show_connection(False)
-                self.show_back_button()
-                self.data.uuid = get_uuid()
-                self.read_connections()
+    @transition_edge_callback(ENTER, interface.OAuthSetup)
+    def enter_OAuthSetup(self, old_state, new_state):
+        self.show_component('openBrowserPage', True)
 
-    def run(self) -> None:
-        """
-        Shows the main window and if there is already an active vpn connection shows the connection screen,
-        otherwise the screen to select a previous connection or the initial screen when no previous selection was made.
-        """
-        self.window.show()
-        try:
-            self.data
-            if self.data.connection_state == NM.VpnConnectionState.ACTIVATED:
-                vc = self.data.vpn_connection
-                auth_url = get_auth_url()
-                if auth_url:
-                    exists = get_current_metadata(auth_url)
-                    if exists:
-                        vc.auth_url = auth_url
-                        vc.token, vc.token_endpoint, vc.authorization_endpoint, vc.api_url, vc.server_name, \
-                            support_contact, vc.profile_id, vc.type, vc.server_image = exists
-                self.act_on_switch = True
-                self.show_connection(False)
-                self.show_back_button()
-            elif self.connections_available():
-                self.show_connections()
-            else:
-                self.show_find_your_institute()
-        except Exception as e:
-            self.show_fatal(f"Got exception {e} can't reach the server, please quit")
+        def fetch_token():
+            url, oauth_session, token_endpoint, auth_endpoint = actions.fetch_token(new_state.server.oauth_login_url)
+            # TODO handle error: self.app.interface_transition('oauth_setup_failure', error="unknown error")
+            # TODO handle cancel: self.app.interface_transition('oauth_setup_cancel')
+            logger.debug(f'got new oauth token: {url!r} {oauth_session!r} {token_endpoint!r} {auth_endpoint!r}')
+            self.app.interface_transition('oauth_setup_success')
 
-    def on_settings_button_released(self, widget, event) -> None:
-        """
-        The settings button has been pressed, shows the settings screen.
-        """
-        logger.debug("on_settings_button_released")
-        self.show_settings()
+        # TODO stop thread when state changes (eg. click on settings)
+        thread_helper(fetch_token)
 
-    def on_help_button_released(self, widget, event) -> None:
-        """
-        The help button has been pressed, open the web browser with information.
-        """
-        logger.debug("on_help_button_released")
+    @transition_edge_callback(EXIT, interface.OAuthSetup)
+    def exit_OAuthSetup(self, old_state, new_state):
+        self.show_component('openBrowserPage', False)
+
+    # ui callbacks
+
+    def on_settings_button_released(self, widget, event):
+        logger.debug("clicked settings button")
+        self.app.interface_transition('toggle_settings')
+
+    def on_help_button_released(self, widget, event):
+        logger.debug("clicked help button")
         webbrowser.open(HELP_URL)
 
-    def on_back_button_released(self, widget, event) -> None:
-        """
-        The back button has been pressed, act accordingly.
-        """
-        logger.debug("on_back_button_released")
-        if self.connections_available():
-            self.show_connections()
-        else:
-            self.show_find_your_institute()
+    def on_back_button_released(self, widget, event):
+        logger.debug("clicked back button")
+        self.app.interface_transition('go_back')
 
     def on_add_other_server_button_clicked(self, button) -> None:
-        """
-        The add server button has been clicked, handle this differently for eduVPN and Let's Connect.
-        """
         logger.debug("on_add_other_server_button_clicked")
-        if self.lets_connect and len(self.find_your_institute_search.get_text()) > 0:
-            logger.debug("on_add_other_server_button_clicked 1")
-            self.handle_add_other_server(self.find_your_institute_search.get_text())
+        self.app.interface_transition('configure_new_server')
+
+    def on_select_server(self, selection):
+        logger.debug("selected search result")
+        (model, tree_iter) = selection.get_selected()
+        selection.unselect_all()
+        if tree_iter is None:
+            logger.info("selection empty")
         else:
-            logger.debug("on_add_other_server_button_clicked 2")
-            self.show_add_other_server()
+            row = model[tree_iter]
+            server = row[1]
+            logger.debug(f"selected server: {server!r}")
+            self.app.interface_transition('connect_to_server', server)
 
-    def handle_add_other_server(self, name: str) -> None:
-        self.data.new_server_name = name
-        self.data.vpn_connection.type = VpnConnection.ConnectionType.OTHER
-        if name.count('.') > 1:
-            if not name.lower().startswith('https://'):
-                name = 'https://' + name
-            if not name.lower().endswith('/'):
-                name = name + '/'
-            logger.debug(f"handle_add_other_server: {name}")
-            if not self.lets_connect:
-                self.disconnect_selection_handlers()
-            self.show_empty()
-            self.setup_connection(name)
-        if not self.lets_connect:
-            self.other_servers_tree_view.get_selection().unselect_all()
+    def on_cancel_oauth_setup_button_clicked(self, _):
+        self.app.interface_transition('oauth_setup_cancel')
 
-    def activate_other_server(self, name: str, index: int) -> None:
-        logger.debug("activate_other_server")
-        self.disconnect_selection_handlers()
-        self.data.vpn_connection = self.connections[index]
-        self.show_empty()
-        self.setup_connection(self.data.vpn_connection.auth_url)
-
-    def on_other_server_selection_changed(self, selection) -> None:
-        logger.debug("on_other_server_selection_changed")
-        logger.debug(f"# selected rows: {selection.count_selected_rows()}")
-        (model, tree_iter) = selection.get_selected()
-        if tree_iter is not None:
-            if self.select_existing_connection:
-                self.activate_other_server(model[tree_iter][0], model[tree_iter][1])
-            else:
-                self.handle_add_other_server(model[tree_iter][0])
-        selection.unselect_all()
-
-    def on_cancel_browser_button_clicked(self, _) -> None:
-        self.show_find_your_institute()
-
-    def on_search_changed(self, _=None) -> None:
-        logger.debug(f"on_search_changed: {self.find_your_institute_search.get_text()}")
-        self.update_search_lists(self.find_your_institute_search.get_text())
-
-    def on_activate_changed(self, _=None) -> None:
-        name = self.find_your_institute_search.get_text()
-        logger.debug(f"on_activate_changed: {name}")
-        if self.lets_connect and len(self.institute_list_model) == 0:  # type: ignore
-            self.handle_add_other_server(name)
+    def on_search_changed(self, _=None):
+        query = self.builder.get_object('findYourInstituteSearch').get_text()
+        logger.debug(f"entered search query: {query}")
+        if self.lets_connect or query.count('.') >= 2:
+            # Anything with two periods is interpreted as a custom server address.
+            self.app.interface_transition('enter_custom_address', address=query)
         else:
-            if len(name) == 0:
-                return
-            one_institute_available = len(self.institute_list_model) == 1  # type: ignore
-            no_institute_available = len(self.institute_list_model) == 0  # type: ignore
-            one_secure_internet_available = len(self.secure_internet_list_model) == 1  # type: ignore
-            no_secure_internet_available = len(self.secure_internet_list_model) == 0  # type: ignore
-            one_other_server_available = len(self.other_servers_list_model) == 1  # type: ignore
-            no_other_server_available = len(self.other_servers_list_model) == 0  # type: ignore
+            self.app.interface_transition('enter_search_query', search_query=query)
 
-            if one_institute_available and no_secure_internet_available and no_other_server_available:
-                self.handle_add_institute(self.institute_list_model[0][0],  # type: ignore
-                                          self.institute_list_model[0][1])  # type: ignore
-            if no_institute_available and one_secure_internet_available and no_other_server_available:
-                self.handle_add_secure_internet(self.secure_internet_list_model[0][0],  # type: ignore
-                                                self.secure_internet_list_model[0][1])  # type: ignore
-            if no_institute_available and no_secure_internet_available and one_other_server_available:
-                self.handle_add_other_server(self.other_servers_list_model[0][0])  # type: ignore
-
-    def handle_add_institute(self, name: str, index: int) -> None:
-        self.data.new_server_name = name
-        self.data.vpn_connection.type = VpnConnection.ConnectionType.INSTITUTE
-        self.disconnect_selection_handlers()
-        base_url = str(self.data.institute_access[index]['base_url'])
-
-        self.data.new_support_contact = self.data.institute_access[index].get('support_contact', None)
-        if not self.data.new_support_contact:
-            self.data.new_support_contact = []
-
-        logger.debug(f"handle_add_institute: {self.data.vpn_connection.server_name} {base_url}")
-        self.show_empty()
-        self.setup_connection(base_url, [], False)
-
-    def activate_institute(self, name: str, index: int) -> None:
-        logger.debug("activate_institute")
-        self.disconnect_selection_handlers()
-        self.data.vpn_connection = self.connections[index]
-        self.show_empty()
-        self.setup_connection(self.data.vpn_connection.auth_url, [], False)
-
-    def on_institute_selection_changed(self, selection) -> None:
-        logger.debug("on_institute_selection_changed")
-        logger.debug(f"# selected rows: {selection.count_selected_rows()}")
-        (model, tree_iter) = selection.get_selected()
-        if tree_iter is not None:
-            if self.select_existing_connection:
-                self.activate_institute(model[tree_iter][0], model[tree_iter][1])
-            else:
-                self.handle_add_institute(model[tree_iter][0], model[tree_iter][1])
-        selection.unselect_all()
-
-    def handle_add_secure_internet(self, name: str, index: int) -> None:
-        self.disconnect_selection_handlers()
-        self.data.new_server_name = name
-        self.data.secure_internet_home = self.data.organisations[index]['secure_internet_home']
-        self.data.vpn_connection.type = VpnConnection.ConnectionType.SECURE
-        self.connect_selection_handlers()
-        self.data.secure_internet_home = self.data.organisations[index]['secure_internet_home']
-        logger.debug(
-            f"handle_add_secure_internet: {self.data.new_server_name} {self.data.secure_internet_home}")
-        self.show_empty()
-        self.setup_connection(self.data.secure_internet_home, self.data.secure_internet, True)
-
-    def activate_secure_internet(self, name: str, index: int) -> None:
-        logger.debug("activate_secure_internet")
-        self.disconnect_selection_handlers()
-        self.data.vpn_connection = self.connections[index]
-        self.show_empty()
-        self.setup_connection(self.data.vpn_connection.auth_url, self.data.secure_internet, True)
-
-    def on_secure_internet_selection_changed(self, selection) -> None:
-        logger.debug("on_secure_internet_selection_changed")
-        logger.debug(f"# selected rows: {selection.count_selected_rows()}")
-        (model, tree_iter) = selection.get_selected()
-        if tree_iter is not None:
-            if self.select_existing_connection:
-                self.activate_secure_internet(model[tree_iter][0], model[tree_iter][1])
-            else:
-                self.handle_add_secure_internet(model[tree_iter][0], model[tree_iter][1])
-        selection.unselect_all()
+    def on_activate_changed(self, _=None):
+        logger.debug("on_activate_changed")
+        # TODO
 
     def on_connection_switch_state_set(self, switch, state):
-        logger.debug(f"on_connection_switch_state_set: {state}")
-        if self.act_on_switch:
-            if state:
-                self.activate_connection()
-            else:
-                self.deactivate_connection()
+        logger.debug("on_activate_changed")
+        if state:
+            self.app.network_transition('reconnect')
+        else:
+            self.app.network_transition('disconnect')
         return True
 
-    def activate_connection(self) -> None:
-        logger.debug("Activating connection")
-        self.data.uuid = get_uuid()
-        if self.data.uuid:
-            GLib.idle_add(lambda: activate_connection(self.client, self.data.uuid))
-        else:
-            raise Exception("No UUID configured, can't activate connection")
-
-    def deactivate_connection(self) -> None:
-        logger.debug("Deactivating connection")
-        self.data.uuid = get_uuid()
-        if self.data.uuid:
-            GLib.idle_add(lambda: deactivate_connection(self.client, self.data.uuid))
-        else:
-            raise Exception("No UUID configured, can't deactivate connection")
-
-    def init_search_list(self) -> None:
-        text_cell = Gtk.CellRendererText()
-        text_cell.set_property("size-points", 14)  # type: ignore
-        col = Gtk.TreeViewColumn(None, text_cell, text=0)  # type: ignore
-        self.institute_tree_view.append_column(col)
-        self.institute_tree_view.set_model(self.institute_list_model)
-        col = Gtk.TreeViewColumn(None, text_cell, text=0)  # type: ignore
-        self.secure_internet_tree_view.append_column(col)
-        self.secure_internet_tree_view.set_model(self.secure_internet_list_model)
-        col = Gtk.TreeViewColumn(None, text_cell, text=0)  # type: ignore
-        self.other_servers_tree_view.append_column(col)
-        self.other_servers_tree_view.set_model(self.other_servers_list_model)
-        col = Gtk.TreeViewColumn(None, text_cell, text=0)  # type: ignore
-        self.profile_tree_view.append_column(col)
-        self.profile_tree_view.set_model(self.profiles_list_model)
-        renderer_pixbuf = Gtk.CellRendererPixbuf()
-        column_pixbuf = Gtk.TreeViewColumn("Image", renderer_pixbuf, pixbuf=1)  # type: ignore
-        self.location_tree_view.append_column(column_pixbuf)
-        col = Gtk.TreeViewColumn(None, text_cell, text=0)  # type: ignore
-        self.location_tree_view.append_column(col)
-        self.location_tree_view.set_model(self.locations_list_model)
-        # self.update_search_lists()
-
-    def update_search_lists(self, search_string="") -> None:
-        if self.lets_connect and len(self.institute_list_model) == 0:  # type: ignore
-            self.find_your_institute_window.hide()
-            self.update_lc_first_search_list(search_string)
-        else:
-            self.find_your_institute_window.show()
-            self.update_all_search_lists(search_string)
-
-    def update_all_search_lists(self, search_string="") -> None:
-        selection = self.institute_tree_view.get_selection()
-        self.disconnect_selection_handlers()
-        self.institute_list_model.clear()  # type: ignore
-        self.secure_internet_list_model.clear()  # type: ignore
-        self.other_servers_list_model.clear()  # type: ignore
-        for i, row in enumerate(self.data.institute_access):
-            display_name = extract_translation(row['display_name'])
-            if re.search(search_string, display_name, re.IGNORECASE):
-                self.institute_list_model.append([display_name, i])  # type: ignore
-        for i, row in enumerate(self.data.organisations):
-            display_name = extract_translation(row['display_name'])
-            if re.search(search_string, display_name, re.IGNORECASE):
-                self.secure_internet_list_model.append([display_name, i])  # type: ignore
-        self.show_search_lists()
-        self.connect_selection_handlers()
-
-    def update_lc_first_search_list(self, search_string="") -> None:
-        logger.debug(f"update_lc_first_search_list: {search_string}")
-
-    def show_find_your_institute(self, clear_text=True) -> None:
-        logger.debug("show_find_your_institute")
-        self.select_existing_connection = False
-        self.data.profiles = {}
-        self.data.locations = []
-        self.data.secure_internet_home = ""
-        self.data.oauth = None
-        self.data.vpn_connection.api_url = ""
-        self.data.vpn_connection.auth_url = ""
-        self.data.vpn_connection.token_endpoint = ""
-        self.data.new_server_name = ""
-        self.data.new_server_image = None
-        self.data.new_support_contact = []
-        self.act_on_switch = False
-
-        self.find_your_institute_page.show()
-        self.find_your_institute_image.show()
-        self.find_your_institute_spacer.show()
-        self.find_your_institute_label.show()
-        self.find_your_institute_search.show()
-        self.add_other_server_row.hide()
-
-        self.find_your_institute_search.disconnect_by_func(self.on_search_changed)
-        if clear_text:
-            self.find_your_institute_search.set_text("")
-        self.find_your_institute_search.grab_focus()
-
-        self.settings_page.hide()
-        self.choose_profile_page.hide()
-        self.choose_location_page.hide()
-        self.open_browser_page.hide()
-        self.connection_page.hide()
-        self.message_page.hide()
-        self.show_back_button(False)
-        if self.lets_connect:
-            self.add_other_server_row.show()
-        else:
-            self.add_other_server_row.hide()
-        self.find_your_institute_search.connect("search-changed", self.on_search_changed)
-        self.update_search_lists()
-
-    def show_connections(self) -> None:
-        logger.debug("show_connections")
-        self.select_existing_connection = True
-        self.disconnect_selection_handlers()
-
-        self.institute_list_model.clear()  # type: ignore
-        self.secure_internet_list_model.clear()  # type: ignore
-        self.other_servers_list_model.clear()  # type: ignore
-
-        for i, connection in enumerate(self.connections):
-            formatted = f"{connection.server_name} {connection.profile_id}"
-            if not self.lets_connect:
-                if connection.type == VpnConnection.ConnectionType.INSTITUTE:
-                    self.institute_list_model.append([formatted, i])  # type: ignore
-                elif connection.type == VpnConnection.ConnectionType.SECURE:
-                    self.secure_internet_list_model.append([formatted, i])  # type: ignore
-            if connection.type == VpnConnection.ConnectionType.OTHER:
-                self.other_servers_list_model.append([formatted, i])  # type: ignore
-
-        self.find_your_institute_page.show()
-        self.find_your_institute_image.hide()
-        self.find_your_institute_spacer.hide()
-        self.find_your_institute_label.hide()
-        self.find_your_institute_search.hide()
-        self.add_other_server_row.show()
-
-        self.settings_page.hide()
-        self.choose_profile_page.hide()
-        self.choose_location_page.hide()
-        self.open_browser_page.hide()
-        self.connection_page.hide()
-        self.message_page.hide()
-        self.show_back_button(False)
-
-        if len(self.institute_list_model) > 0:  # type: ignore
-            self.institute_access_header.show()
-            self.institute_tree_view.show()
-        else:
-            self.institute_access_header.hide()
-            self.institute_tree_view.hide()
-        if len(self.secure_internet_list_model):  # type: ignore
-            self.secure_internet_header.show()
-            self.secure_internet_tree_view.show()
-        else:
-            self.secure_internet_header.hide()
-            self.secure_internet_tree_view.hide()
-        if len(self.other_servers_list_model) > 0:  # type: ignore
-            self.other_servers_header.show()
-            self.other_servers_tree_view.show()
-        else:
-            self.other_servers_header.hide()
-            self.other_servers_tree_view.hide()
-
-        self.connect_selection_handlers()
-
-    def connections_available(self) -> bool:
-        for connection in self.connections:
-            if not self.lets_connect:
-                return True
-            elif connection.type == VpnConnection.ConnectionType.OTHER:
-                return True
-        return False
-
-    def show_add_other_server(self) -> None:
-        logger.debug("show_add_other_server")
-        self.show_find_your_institute()
-
-    def show_settings(self) -> None:
-        logger.debug("show_settings")
-        self.find_your_institute_page.hide()
-        self.settings_page.show()
-        self.choose_profile_page.hide()
-        self.choose_location_page.hide()
-        self.open_browser_page.hide()
-        self.connection_page.hide()
-        self.message_page.hide()
-        self.show_back_button()
-        self.add_other_server_row.hide()
-
-    def show_choose_profile(self) -> None:
-        logger.debug("show_choose_profile")
-        if len(self.data.profiles) > 1:
-            self.find_your_institute_page.hide()
-            self.settings_page.hide()
-            self.choose_profile_page.show()
-            self.choose_location_page.hide()
-            self.open_browser_page.hide()
-            self.connection_page.hide()
-            self.message_page.hide()
-            self.show_back_button()
-            self.add_other_server_row.hide()
-            select = self.profile_tree_view.get_selection()
-            select.unselect_all()
-            select.connect("changed", self.on_profile_selection_changed)
-        else:
-            logger.warning("ERROR: should only be called when there are profiles to choose from")
-            self.show_settings()
-
-    def show_choose_location(self) -> None:
-        logger.debug("show_choose_location")
-        if len(self.data.locations) > 1:
-            self.find_your_institute_page.hide()
-            self.settings_page.hide()
-            self.choose_profile_page.hide()
-            self.choose_location_page.show()
-            self.open_browser_page.hide()
-            self.connection_page.hide()
-            self.message_page.hide()
-            self.show_back_button()
-            self.add_other_server_row.hide()
-            select = self.location_tree_view.get_selection()
-            select.unselect_all()
-            select.connect("changed", self.on_location_selection_changed)
-        else:
-            logger.warning("ERROR: should only be called when there are profiles to choose from")
-            self.show_settings()
-
-    def show_open_browser(self) -> None:
-        """
-        Show the open browser screen
-        """
-        logger.debug("show_open_browser")
-        self.find_your_institute_page.hide()
-        self.settings_page.hide()
-        self.choose_profile_page.hide()
-        self.choose_location_page.hide()
-        self.open_browser_page.show()
-        self.connection_page.hide()
-        self.message_page.hide()
-        self.show_back_button(False)
-        self.add_other_server_row.hide()
-
-    def show_connection(self, start_connection: bool = True) -> None:
-        logger.debug("show_connection")
-        self.find_your_institute_page.hide()
-        self.settings_page.hide()
-        self.choose_profile_page.hide()
-        self.choose_location_page.hide()
-        self.open_browser_page.hide()
-        self.connection_page.show()
-        self.message_page.hide()
-        self.show_back_button()
-        self.add_other_server_row.hide()
-        self.connection_info_top_row.hide()
-        self.profiles_sub_page.hide()
-        self.connection_sub_page.hide()
-        self.connection_info_grid.hide()
-        self.connection_info_bottom_row.hide()
-        self.server_image.hide()
-        self.server_label.set_text(self.data.vpn_connection.server_name)
-        if self.data.vpn_connection.server_image is not None:
-            self.server_image.set_from_file(self.data.vpn_connection.server_image)
-            self.server_image.show()
-        else:
-            self.server_image.hide()
-
-        support = ""
-        if len(self.data.vpn_connection.support_contact) > 0:
-            support = "Support: " + ", ".join(self.data.vpn_connection.support_contact)
-        self.support_label.set_text(support)
-        if start_connection:
-            self.show_back_button()
-            self.act_on_switch = False
-            logger.debug(f"vpn_state: {self.data.connection_state}")
-            self.auto_connect = True
-            if self.data.connection_state == NM.VpnConnectionState.ACTIVATED:
-                GLib.idle_add(lambda: self.deactivate_connection())
-            else:
-                self.activate_connection()
-        else:
-            self.show_back_button(True, False)
-
-    def show_empty(self) -> None:
-        logger.debug("show_empty")
-        self.find_your_institute_page.hide()
-        self.settings_page.hide()
-        self.choose_profile_page.hide()
-        self.choose_location_page.hide()
-        self.open_browser_page.hide()
-        self.connection_page.hide()
-        self.message_page.hide()
-        self.show_back_button(True, False)
-        self.add_other_server_row.hide()
-        self.connection_info_top_row.hide()
-        self.profiles_sub_page.hide()
-        self.connection_sub_page.hide()
-        self.connection_info_grid.hide()
-        self.connection_info_bottom_row.hide()
-
-    def show_message(self, label, text, callback) -> None:
-        logger.debug(f"show_message: {label} {text}")
-        self.find_your_institute_page.hide()
-        self.settings_page.hide()
-        self.choose_profile_page.hide()
-        self.choose_location_page.hide()
-        self.open_browser_page.hide()
-        self.connection_page.hide()
-        self.show_back_button(True, False)
-        self.add_other_server_row.hide()
-        self.connection_info_top_row.hide()
-        self.profiles_sub_page.hide()
-        self.connection_sub_page.hide()
-        self.connection_info_grid.hide()
-        self.connection_info_bottom_row.hide()
-        self.message_page.show()
-        self.message_label.set_text(label)
-        self.message_text.set_text(text)
-        self.message_button.connect("clicked", callback)
-
-    def show_fatal(self, text) -> None:
-        logger.debug(f"show_fatal: {text}")
-        self.show_message("Fatal error", text, Gtk.main_quit)
-
-    def update_connection_state(self, state: NM.VpnConnectionState) -> None:
-        self.data.connection_state = state
-
-        connection_state_mapping = {
-            NM.VpnConnectionState.UNKNOWN: ["Connection state unknown", "desktop-default.png"],
-            NM.VpnConnectionState.PREPARE: ["Preparing to connect", "desktop-connecting.png"],
-            NM.VpnConnectionState.NEED_AUTH: ["Needs authorization credentials", "desktop-connecting.png"],
-            NM.VpnConnectionState.CONNECT: ["Connection is being established", "desktop-connecting.png"],
-            NM.VpnConnectionState.IP_CONFIG_GET: ["Getting an IP address", "desktop-connecting.png"],
-            NM.VpnConnectionState.ACTIVATED: ["Connection active", "desktop-connected.png"],
-            NM.VpnConnectionState.FAILED: ["Connection failed", "desktop-not-connected.png"],
-            NM.VpnConnectionState.DISCONNECTED: ["Disconnected", "desktop-default.png"],
-        }
-        self.connection_status_label.set_text(connection_state_mapping[state][0])
-        self.connection_status_image.set_from_file(IMAGE_PREFIX + connection_state_mapping[state][1])
-        if state == NM.VpnConnectionState.UNKNOWN:
-            self.current_connection_sub_page.hide()
-        else:
-            self.current_connection_sub_page.show()
-
-    def on_profile_selection_changed(self, selection) -> None:
-        logger.debug("on_profile_selection_changed")
-        logger.debug(f"# selected rows: {selection.count_selected_rows()}")
-        (model, tree_iter) = selection.get_selected()
-        if tree_iter is not None:
-            display_name = model[tree_iter][0]
-            i = model[tree_iter][1]
-            # self.data.vpn_connection.profile_name = display_name
-            selection.disconnect_by_func(self.on_profile_selection_changed)
-            self.data.vpn_connection.profile_id = str(self.data.profiles[i]['profile_id'])
-            logger.debug(f"on_profile_selection_changed: {display_name} {self.data.vpn_connection.profile_id}")
-            self.finalize_configuration(self.data.vpn_connection.profile_id)
-        selection.unselect_all()
-
-    def show_search_lists(self) -> None:
-        name = self.find_your_institute_search.get_text()
-        search_term = len(name) > 0
-        dot_count = name.count('.')
-
-        if dot_count > 1:
-            self.other_servers_list_model.clear()  # type: ignore
-            self.other_servers_list_model.append([name, 0])  # type: ignore
-
-        if search_term:
-            self.find_your_institute_image.hide()
-            self.find_your_institute_spacer.hide()
-            self.add_other_server_row.hide()
-        else:
-            self.find_your_institute_image.show()
-            self.find_your_institute_spacer.show()
-            self.add_other_server_row.hide()
-
-        if len(self.institute_list_model) > 0 and search_term:  # type: ignore
-            self.institute_access_header.show()
-            self.institute_tree_view.show()
-        else:
-            self.institute_access_header.hide()
-            self.institute_tree_view.hide()
-        if len(self.secure_internet_list_model) > 0 and search_term:  # type: ignore
-            self.secure_internet_header.show()
-            self.secure_internet_tree_view.show()
-        else:
-            self.secure_internet_header.hide()
-            self.secure_internet_tree_view.hide()
-        if len(self.other_servers_list_model) > 0 and search_term:  # type: ignore
-            self.other_servers_header.show()
-            self.other_servers_tree_view.show()
-        else:
-            self.other_servers_header.hide()
-            self.other_servers_tree_view.hide()
-
-    def on_location_selection_changed(self, selection) -> None:
-        logger.debug("on_location_selection_changed")
-        logger.debug(f"# selected rows: {selection.count_selected_rows()}")
-        (model, tree_iter) = selection.get_selected()
-        if tree_iter is not None:
-            self.data.new_server_name = model[tree_iter][0]
-            display_name = model[tree_iter][0]
-            i = model[tree_iter][2]
-            selection.disconnect_by_func(self.on_location_selection_changed)
-            logger.debug(self.data.locations[i])
-            base_url = str(self.data.locations[i]['base_url'])
-            country_code = self.data.locations[i]['country_code']
-            self.data.new_server_image = FLAG_PREFIX + country_code + "@1,5x.png"
-            if 'support_contact' in self.data.locations[i]:
-                self.data.new_support_contact = self.data.locations[i]['support_contact']
-            logger.debug(f"on_location_selection_changed: {display_name} {base_url}")
-            self.show_empty()
-            thread_helper(lambda: handle_location_thread(base_url, self))
-        selection.unselect_all()
-
-    def setup_connection(self, auth_url, secure_internet: list = [], interactive: bool = False) -> None:
-        logger.debug(f"setup_connection auth_url:{auth_url} secure_internet:{secure_internet} interactive:{interactive}")
-
-        self.data.vpn_connection.auth_url = auth_url
-        self.data.locations = secure_internet
-
-        logger.debug(f"starting procedure with auth_url: {self.data.vpn_connection.auth_url}")
-        exists = get_current_metadata(self.data.vpn_connection.auth_url)
-
-        if exists:
-            token, self.data.vpn_connection.token_endpoint, self.data.vpn_connection.authorization_endpoint, api_url, \
-                display_name, support_contact, self.data.vpn_connection.profile_id, self.data.vpn_connection.type, self.data.vpn_connection.server_image = exists
-            thread_helper(lambda: restoring_token_thread(token, self.data.vpn_connection.token_endpoint, self))
-        else:
-            self.show_open_browser()
-            thread_helper(lambda: fetch_token_thread(self))
-
-    def token_available(self) -> None:
-        """
-        Called when the token is available
-        """
-        if self.data.locations:
-            thread_helper(lambda: handle_secure_internet_thread(self))
-        else:
-            self.handle_profiles()
-
-    def handle_profiles(self) -> None:
-        logger.debug(f"using api_url: {self.data.vpn_connection.api_url}")
-        thread_helper(lambda: handle_profiles_thread(self))
-
-    def finalize_configuration(self, profile_id) -> None:
-        logger.debug("finalize_configuration")
-        self.show_connection(False)
-        thread_helper(lambda: finalize_configuration_thread(profile_id, self))
-
-    def configuration_finalized_cb(self, result):
-        logger.debug(f"configuration_finalized_cb: {result}")
-        GLib.idle_add(lambda: self.show_connection())
-
-    def configuration_finalized(self, config, private_key, certificate) -> None:
-
-        set_metadata(
-            auth_url=self.data.vpn_connection.auth_url,
-            token=self.data.oauth.token,
-            token_endpoint=self.data.vpn_connection.token_endpoint,
-            authorization_endpoint=self.data.vpn_connection.authorization_endpoint,
-            api_url=self.data.vpn_connection.api_url,
-            display_name=self.data.new_server_name,
-            support_contact=self.data.new_support_contact,
-            profile_id=self.data.vpn_connection.profile_id,
-            con_type=self.data.vpn_connection.type,
-            country_id=self.data.vpn_connection.server_image  # TODO Needs to change in only country code
-        )
-        if nm_available():
-            logger.info("nm available:")
-            save_connection(self.client, config, private_key, certificate, self.configuration_finalized_cb)
-        else:
-            target = Path('eduVPN.ovpn').resolve()
-            write_config(config, private_key, certificate, target)
-            GLib.idle_add(lambda: self.connection_written())
-
-    def connection_written(self) -> None:
-        logger.debug("connection_written")
-        self.show_connection()
-
-    def show_back_button(self, show: bool = True, enabled: bool = True):
-        if show:
-            self.back_button.show()
-        else:
-            self.back_button.hide()
-        self.back_button_event_box.set_sensitive(enabled)
-
-    def connect_selection_handlers(self):
-        if not self.selection_handlers_connected:
-            select = self.institute_tree_view.get_selection()
-            select.connect("changed", self.on_institute_selection_changed)
-            select = self.secure_internet_tree_view.get_selection()
-            select.connect("changed", self.on_secure_internet_selection_changed)
-            select = self.other_servers_tree_view.get_selection()
-            select.connect("changed", self.on_other_server_selection_changed)
-            self.selection_handlers_connected = True
-
-    def disconnect_selection_handlers(self):
-        if self.selection_handlers_connected:
-            select = self.institute_tree_view.get_selection()
-            select.disconnect_by_func(self.on_institute_selection_changed)
-            select = self.secure_internet_tree_view.get_selection()
-            select.disconnect_by_func(self.on_secure_internet_selection_changed)
-            select = self.other_servers_tree_view.get_selection()
-            select.disconnect_by_func(self.on_other_server_selection_changed)
-            self.selection_handlers_connected = False
-
-
-def fetch_token_thread(gui: EduVpnGui) -> None:
-    logger.debug("fetching token")
-    try:
-        gui.data.vpn_connection.api_url, gui.data.vpn_connection.token_endpoint, gui.data.vpn_connection.authorization_endpoint = get_info(
-            gui.data.vpn_connection.auth_url)
-        gui.data.oauth = get_oauth(gui.data.vpn_connection.token_endpoint, gui.data.vpn_connection.authorization_endpoint)
-        GLib.idle_add(lambda: gui.token_available())
-    except Exception as e:
-        msg = f"Got exception {e} requesting {gui.data.vpn_connection.auth_url}"
-        logger.debug(msg)
-        GLib.idle_add(lambda: gui.show_find_your_institute(clear_text=False))
-
-
-def restoring_token_thread(token, token_endpoint, gui: EduVpnGui) -> None:
-    logger.debug("token exists, restoring")
-    gui.data.oauth = OAuth2Session(client_id=CLIENT_ID, token=token, auto_refresh_url=token_endpoint)
-    gui.data.oauth.refresh_token(token_url=gui.data.vpn_connection.token_endpoint)
-    gui.data.vpn_connection.api_url, _, _ = get_info(gui.data.vpn_connection.auth_url)
-    GLib.idle_add(lambda: gui.token_available())
-
-
-def handle_location_thread(base_url: str, gui: EduVpnGui) -> None:
-    logger.debug("fetching location info")
-    gui.data.vpn_connection.api_url, _, _ = get_info(base_url)
-    GLib.idle_add(lambda: gui.handle_profiles())
-
-
-def handle_profiles_thread(gui: EduVpnGui) -> None:
-    gui.data.oauth.refresh_token(token_url=gui.data.vpn_connection.token_endpoint)
-    gui.data.profiles = list_profiles(gui.data.oauth, gui.data.vpn_connection.api_url)
-    print(gui.data.profiles)
-    if len(gui.data.profiles) > 1:
-        gui.profiles_list_model.clear()  # type: ignore
-        for i, profile in enumerate(gui.data.profiles):
-            gui.profiles_list_model.append([profile['display_name'], i])  # type: ignore
-        GLib.idle_add(lambda: gui.show_choose_profile())
-    else:
-        gui.data.vpn_connection.profile_id = str(gui.data.profiles[0]['profile_id'])
-        GLib.idle_add(lambda: gui.finalize_configuration(gui.data.vpn_connection.profile_id))
-
-
-def handle_secure_internet_thread(gui: EduVpnGui) -> None:
-    if len(gui.data.secure_internet) > 1:
-        gui.locations_list_model.clear()  # type: ignore
-        for i, location in enumerate(gui.data.locations):
-            flag_location = FLAG_PREFIX + location['country_code'] + "@1,5x.png"
-            if os.path.exists(flag_location):
-                flag_image = GdkPixbuf.Pixbuf.new_from_file(flag_location)  # type: ignore
-                country_name = retrieve_country_name(location['country_code'])
-                gui.locations_list_model.append([country_name, flag_image, i])  # type: ignore
-
-        GLib.idle_add(lambda: gui.show_choose_location())
-    else:
-        base_url = str(gui.data.locations[0]['base_url'])
-        GLib.idle_add(lambda: gui.finalize_configuration(base_url))
-
-
-def finalize_configuration_thread(profile_id: str, gui: EduVpnGui) -> None:
-    logger.debug("finalize_configuration_thread")
-    config = get_config(gui.data.oauth, gui.data.vpn_connection.api_url, profile_id)
-    private_key, certificate = create_keypair(gui.data.oauth, gui.data.vpn_connection.api_url)
-
-    set_auth_url(gui.data.vpn_connection.auth_url)
-    GLib.idle_add(lambda: gui.configuration_finalized(config, private_key, certificate))
+    def on_profile_selection_changed(self, selection):
+        logger.debug("on_activate_changed")
+        # TODO

--- a/eduvpn/ui/utils.py
+++ b/eduvpn/ui/utils.py
@@ -18,3 +18,13 @@ def error_helper(parent: GObject, msg_big: str, msg_small: str) -> None:  # type
     error_dialog.format_secondary_text(str(msg_small))  # type: ignore
     error_dialog.run()  # type: ignore
     error_dialog.hide()  # type: ignore
+
+def show_ui_component(builder, component: str, show: bool):
+    """
+    Set the visibility of a UI component.
+    """
+    component = builder.get_object(component)
+    if show:
+        component.show()
+    else:
+        component.hide()

--- a/eduvpn/ui/utils.py
+++ b/eduvpn/ui/utils.py
@@ -1,11 +1,13 @@
 from eduvpn.utils import logger
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '3.0')  # noqa: E402
 from gi.repository import Gtk, GObject
 
 
 # ui thread
-def error_helper(parent: GObject, msg_big: str, msg_small: str) -> None:  # type: ignore
+def error_helper(parent: GObject,
+                 msg_big: str,
+                 msg_small: str) -> None:  # type: ignore
     """
     Shows a GTK error message dialog.
     args:
@@ -14,10 +16,13 @@ def error_helper(parent: GObject, msg_big: str, msg_small: str) -> None:  # type
         msg_small (str): the small string
     """
     logger.error(f"{msg_big}: {msg_small}")
-    error_dialog = Gtk.MessageDialog(parent, 0, Gtk.MessageType.ERROR, Gtk.ButtonsType.OK, str(msg_big))  # type: ignore
+    error_dialog = Gtk.MessageDialog(
+        parent, 0, Gtk.MessageType.ERROR, Gtk.ButtonsType.OK, str(msg_big),
+        )  # type: ignore
     error_dialog.format_secondary_text(str(msg_small))  # type: ignore
     error_dialog.run()  # type: ignore
     error_dialog.hide()  # type: ignore
+
 
 def show_ui_component(builder, component: str, show: bool):
     """

--- a/eduvpn/ui/utils.py
+++ b/eduvpn/ui/utils.py
@@ -1,11 +1,11 @@
 from eduvpn.utils import logger
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk
+from gi.repository import Gtk, GObject
 
 
 # ui thread
-def error_helper(parent: Gtk.GObject, msg_big: str, msg_small: str) -> None:  # type: ignore
+def error_helper(parent: GObject, msg_big: str, msg_small: str) -> None:  # type: ignore
     """
     Shows a GTK error message dialog.
     args:

--- a/eduvpn/ui/utils.py
+++ b/eduvpn/ui/utils.py
@@ -5,9 +5,9 @@ from gi.repository import Gtk, GObject
 
 
 # ui thread
-def error_helper(parent: GObject,
+def error_helper(parent: GObject,  # type: ignore
                  msg_big: str,
-                 msg_small: str) -> None:  # type: ignore
+                 msg_small: str) -> None:
     """
     Shows a GTK error message dialog.
     args:
@@ -16,9 +16,13 @@ def error_helper(parent: GObject,
         msg_small (str): the small string
     """
     logger.error(f"{msg_big}: {msg_small}")
-    error_dialog = Gtk.MessageDialog(
-        parent, 0, Gtk.MessageType.ERROR, Gtk.ButtonsType.OK, str(msg_big),
-        )  # type: ignore
+    error_dialog = Gtk.MessageDialog(  # type: ignore
+        parent,
+        0,
+        Gtk.MessageType.ERROR,  # type: ignore
+        Gtk.ButtonsType.OK,  # type: ignore
+        str(msg_big),
+    )
     error_dialog.format_secondary_text(str(msg_small))  # type: ignore
     error_dialog.run()  # type: ignore
     error_dialog.hide()  # type: ignore
@@ -30,6 +34,6 @@ def show_ui_component(builder, component: str, show: bool):
     """
     component = builder.get_object(component)
     if show:
-        component.show()
+        component.show()  # type: ignore
     else:
-        component.hide()
+        component.hide()  # type: ignore

--- a/eduvpn/utils.py
+++ b/eduvpn/utils.py
@@ -1,5 +1,5 @@
 import threading
-from functools import lru_cache
+from functools import lru_cache, partial, wraps
 from logging import getLogger
 from os import path
 from sys import prefix
@@ -41,3 +41,28 @@ def thread_helper(func: Callable) -> threading.Thread:
     thread.daemon = True
     thread.start()
     return thread
+
+def run_in_background_thread(func):
+    """
+    Decorator for functions that must always run
+    in a background thread.
+    """
+
+    @wraps(func)
+    def background_func(*args, **kwargs):
+        thread_helper(partial(func, *args, **kwargs))
+
+    return background_func
+
+def run_in_main_gtk_thread(func):
+    """
+    Decorator for functions that must always run
+    in the main GTK thread.
+    """
+    from gi.repository import GLib
+
+    @wraps(func)
+    def main_gtk_thread_func(*args, **kwargs):
+        GLib.idle_add(partial(func, *args, **kwargs))
+
+    return main_gtk_thread_func

--- a/eduvpn/utils.py
+++ b/eduvpn/utils.py
@@ -42,6 +42,7 @@ def thread_helper(func: Callable) -> threading.Thread:
     thread.start()
     return thread
 
+
 def run_in_background_thread(func):
     """
     Decorator for functions that must always run
@@ -53,6 +54,7 @@ def run_in_background_thread(func):
         thread_helper(partial(func, *args, **kwargs))
 
     return background_func
+
 
 def run_in_main_gtk_thread(func):
     """

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -1,0 +1,123 @@
+# python-eduvpn-client - The GNU/Linux eduVPN client and Python API
+#
+# Copyright: 2017, The Commons Conservancy eduVPN Programme
+# SPDX-License-Identifier: GPL-3.0+
+
+from typing import Set
+import unittest
+from unittest.mock import Mock
+
+from eduvpn.state_machine import (
+    ENTER, EXIT, StateMachine, transition_callback, transition_edge_callback,
+    InvalidStateTransition)
+from tests.mock_config import mock_config_dict
+
+
+class StateMachineTests(unittest.TestCase):
+    def test_state_transition(self):
+        initial_state = Mock()
+        final_state = object()
+        initial_state.perform_the_transition.return_value = final_state
+
+        sm = StateMachine(initial_state)
+        self.assertIs(sm.state, initial_state)
+
+        sm.transition('perform_the_transition', 1, x=2)
+        self.assertIs(sm.state, final_state)
+        initial_state.perform_the_transition.assert_called_once_with(1, x=2)
+
+    def test_generic_callback(self):
+        initial_state = Mock()
+        final_state = object()
+        initial_state.perform_the_transition.return_value = final_state
+        callback = Mock()
+
+        sm = StateMachine(initial_state)
+        sm.register_generic_callback(callback)
+        sm.transition('perform_the_transition')
+        callback.assert_called_once_with(initial_state, final_state)
+
+    def test_edge_callback(self):
+        class InitialState:
+            def perform_the_transition(self):
+                return final_state
+
+        class FinalState:
+            pass
+
+        class OtherState:
+            pass
+
+        initial_state = InitialState()
+        final_state = FinalState()
+
+        enter_initial_callback = Mock()
+        exit_initial_callback = Mock()
+        enter_final_callback = Mock()
+        exit_final_callback = Mock()
+        other_callback = Mock()
+
+        sm = StateMachine(initial_state)
+        sm.register_edge_callback(InitialState, ENTER, enter_initial_callback)
+        sm.register_edge_callback(InitialState, EXIT, exit_initial_callback)
+        sm.register_edge_callback(FinalState, ENTER, enter_final_callback)
+        sm.register_edge_callback(FinalState, EXIT, exit_final_callback)
+        sm.register_edge_callback(OtherState, ENTER, other_callback)
+        sm.register_edge_callback(OtherState, EXIT, other_callback)
+
+        sm.transition('perform_the_transition')
+        exit_initial_callback.assert_called_once_with(
+            initial_state, final_state)
+        enter_final_callback.assert_called_once_with(
+            initial_state, final_state)
+
+        enter_initial_callback.assert_not_called()
+        exit_final_callback.assert_not_called()
+        other_callback.assert_not_called()
+
+    def test_connect_object_callbacks(self):
+        class BaseState:
+            pass
+
+        class InitialState(BaseState):
+            def perform_the_transition(self):
+                return final_state
+
+        class FinalState(BaseState):
+            pass
+
+        class OtherBaseState:
+            pass
+
+        initial_state = InitialState()
+        final_state = FinalState()
+
+        class Connector:
+            def __init__(self):
+                self.calls: Set[str] = set()
+
+            @transition_callback(BaseState)
+            def any(self, old, new):
+                self.calls.add(('any', old, new))
+
+            @transition_edge_callback(ENTER, InitialState)
+            def enter_initial(self, old, new):
+                self.calls.add(('enter_initial', old, new))
+
+            @transition_edge_callback(EXIT, InitialState)
+            def exit_initial(self, old, new):
+                self.calls.add(('exit_initial', old, new))
+
+            @transition_callback(OtherBaseState)
+            def other(self, old, new):
+                # This callback targets another state machine.
+                raise AssertionError
+
+        connector = Connector()
+        sm = StateMachine(initial_state)
+        sm.connect_object_callbacks(connector, BaseState)
+        sm.transition('perform_the_transition')
+        self.assertEqual(connector.calls, {
+            ('any', initial_state, final_state),
+            ('exit_initial', initial_state, final_state),
+        })


### PR DESCRIPTION
This PR addresses #258 by providing the framework and partial implementations of the state machines running the application, as well as their interaction with the UI.

A specific goal is to separate the state of the application into independent parts. To that end, the state of the network and interface have been separated into two state machines, as they both operate more or less independently. The complete app state is collected in the Application type.

The state machine is wrapped in a type with the goal of providing a nicer api to the UI through the transition registration decorators. This part is somewhat complex, but IMHO leads to a nicer api for UI. For one, it cleanly separates the UI from the app state, while also avoiding long lists mapping methods to events.

From here I'll work my way down the state machines, let me know if you can tell what goes in the places marked TODO.

The UI is functional up to the OAuth phase.
It solves issue #292, and avoids modifying GTK components in background threads (issue #291).
It's also a start towards #311.

With this done, I'll try to provide smaller PRs :)