### PR TITLE
Show previously configured connections on app startup

### DIFF
--- a/eduvpn/app.py
+++ b/eduvpn/app.py
@@ -29,14 +29,17 @@ class Application:
         """
         # Check if a previous network profile exists.
         self.current_network_uuid = get_uuid()
+        kwargs = {}
         if self.current_network_uuid:
+            from .server import CustomServer  # TODO x
+            kwargs['server'] = CustomServer('demo.eduvpn.nl')  # TODO x
             if 0:  # TODO
                 transition = 'found_active_connection'
             else:
                 transition = 'found_previous_connection'
         else:
             transition = 'no_previous_connection_found'
-        self.network_transition_threadsafe(transition)
+        self.network_transition_threadsafe(transition, **kwargs)
 
     @run_in_background_thread('init-server-db')
     def initialize_server_db(self):

--- a/eduvpn/interface/utils.py
+++ b/eduvpn/interface/utils.py
@@ -1,9 +1,0 @@
-from ..server import SecureInternetServer, OrganisationServer
-
-
-class SecureInternetLocation:
-    def __init__(self,
-                 server: OrganisationServer,
-                 location: SecureInternetServer):
-        self.server = server
-        self.location = location

--- a/eduvpn/network.py
+++ b/eduvpn/network.py
@@ -2,7 +2,7 @@ import logging
 from .nm import get_client, activate_connection, deactivate_connection
 from .state_machine import BaseState
 from .app import Application
-from .server import Server
+from .server import ConfiguredServer as Server
 
 
 logger = logging.getLogger(__name__)

--- a/eduvpn/ui/ui.py
+++ b/eduvpn/ui/ui.py
@@ -158,6 +158,8 @@ class EduVpnGui:
     def enter_search(self, old_state, new_state):
         if not isinstance(old_state, interface_state.configure_server_states):
             self.builder.get_object('findYourInstituteSearch').grab_focus()
+            search.show_result_components(self.builder, True)
+            search.show_search_components(self.builder, True)
             search.init_server_search(self.builder)
             search.connect_selection_handlers(
                 self.builder, self.on_select_server)
@@ -165,6 +167,8 @@ class EduVpnGui:
     @transition_edge_callback(EXIT, interface_state.configure_server_states)
     def exit_search(self, old_state, new_state):
         if not isinstance(new_state, interface_state.configure_server_states):
+            search.show_result_components(self.builder, False)
+            search.show_search_components(self.builder, False)
             search.exit_server_search(self.builder)
             search.disconnect_selection_handlers(
                 self.builder, self.on_select_server)
@@ -188,6 +192,25 @@ class EduVpnGui:
         search.update_results(self.builder, [CustomServer(new_state.address)])
         if not isinstance(old_state, interface_state.configure_server_states):
             self.set_search_text(new_state.address)
+
+    @transition_edge_callback(ENTER, interface_state.MainState)
+    def enter_MainState(self, old_state, new_state):
+        search.show_result_components(self.builder, True)
+        self.show_component('addOtherServerRow', True)
+        self.show_component('addOtherServerButton', True)
+        search.update_results(self.builder, new_state.servers)
+        search.init_server_search(self.builder)
+        search.connect_selection_handlers(
+            self.builder, self.on_select_server)
+
+    @transition_edge_callback(EXIT, interface_state.MainState)
+    def exit_MainState(self, old_state, new_state):
+        search.show_result_components(self.builder, False)
+        self.show_component('addOtherServerRow', False)
+        self.show_component('addOtherServerButton', False)
+        search.exit_server_search(self.builder)
+        search.disconnect_selection_handlers(
+            self.builder, self.on_select_server)
 
     @transition_edge_callback(ENTER, interface_state.OAuthSetup)
     def enter_OAuthSetup(self, old_state, new_state):


### PR DESCRIPTION
If you've used the app before, the previously configured connections are now shown to reconnect immediately.

This also includes a cleanup of the type hints for the various server types, I'm sorry about the noise this causes but I hope this clears some things up.