### PR TITLE
Prevent tests from being installed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,4 +8,5 @@ include share/eduvpn/images/*
 include share/eduvpn/letsconnect/*
 include share/eduvpn/images/flags/png/*
 include doc/*
+include tests/*
 

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ for dir in glob('share/locale/*/LC_MESSAGES'):
 setup(
     name="eduvpn_client",
     version=__version__,
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     data_files=data_files,
     install_requires=install_requires,
     extras_require=extras_require,


### PR DESCRIPTION
Having `__init__.py` in the tests folder causes `find_packages` to consider it a package to be installed.