### PR TITLE
Allow user defined config directory using $XDG_CONFIG_HOME

### DIFF
--- a/eduvpn/settings.py
+++ b/eduvpn/settings.py
@@ -1,9 +1,9 @@
 from pathlib import Path
-from eduvpn.utils import get_prefix
+from eduvpn.utils import get_prefix, get_config_dir
 
 prefix = get_prefix()
 
-CONFIG_PREFIX = Path("~/.config/eduvpn/").expanduser().resolve()
+CONFIG_PREFIX = (Path(get_config_dir()).expanduser() / "eduvpn").resolve()
 CONFIG_DIR_MODE = 0o700
 CONFIG_JSON_PREFIX = "2.0_"
 

--- a/eduvpn/utils.py
+++ b/eduvpn/utils.py
@@ -2,7 +2,7 @@ from typing import Optional, Callable
 import threading
 from functools import lru_cache, partial, wraps
 from logging import getLogger
-from os import path
+from os import path, environ
 from sys import prefix
 
 logger = getLogger(__file__)
@@ -28,6 +28,10 @@ def get_prefix() -> str:
         if path.isfile(path.join(option, target)):
             return option
     raise Exception("Can't find eduVPN installation")
+
+
+def get_config_dir() -> str:
+    return environ.get("XDG_CONFIG_HOME", "~/.config")
 
 
 def custom_server_oauth_url(address):


### PR DESCRIPTION
Allow users to use a different configuration directory using the $XDG_CONFIG_HOME environment variable from the xdg base directory spec: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html/