### PR TITLE
Remove `chdir()` call.

### DIFF
--- a/eduvpn/ui/ui.py
+++ b/eduvpn/ui/ui.py
@@ -67,11 +67,23 @@ def get_validity_text(validity: Optional[Validity]) -> str:
         return dstr + hstr
 
 
-def get_template_path(filename: str) -> str:
-    return os.path.join(get_prefix(), 'share/eduvpn/builder', filename)
+def get_template(filename: str) -> str:
+    path = os.path.join(get_prefix(), 'share/eduvpn/builder', filename)
+    relpath = os.path.relpath(
+        os.path.join(get_prefix(), 'share/eduvpn'),
+        os.getcwd(),
+    )
+    with open(path) as f:
+        return f.read().replace(
+            '<property name="pixbuf">../images',
+            f'<property name="pixbuf">{relpath}/images',
+        ).replace(
+            '<property name="icon">../',
+            f'<property name="icon">{relpath}/',
+        )
 
 
-@GtkTemplate(filename=get_template_path('mainwindow.ui'))
+@GtkTemplate(string=get_template('mainwindow.ui'))
 class EduVpnGtkWindow(Gtk.ApplicationWindow):
     __gtype_name__ = "ApplicationWindow"
 

--- a/eduvpn/ui/ui.py
+++ b/eduvpn/ui/ui.py
@@ -134,9 +134,6 @@ class EduVpnGtkWindow(Gtk.ApplicationWindow):
     error_acknowledge_button = GtkTemplate.Child('errorAcknowledgeButton')
 
     def __init__(self, *, application: Application):  # type: ignore
-        # Fix the cwd for the image paths in the interface template to resolve.
-        os.chdir('share/eduvpn/builder')
-
         super().__init__(application=application)  # type: ignore
         self.app = application.app  # type: ignore
 

--- a/share/eduvpn/builder/mainwindow.ui
+++ b/share/eduvpn/builder/mainwindow.ui
@@ -36,7 +36,7 @@
                   <object class="GtkImage" id="backButton">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="pixbuf">../images/back.png</property>
+                    <property name="pixbuf">share/eduvpn/images/back.png</property>
                   </object>
                 </child>
               </object>
@@ -54,7 +54,7 @@
                 <property name="can_focus">False</property>
                 <property name="margin_left">10</property>
                 <property name="margin_right">10</property>
-                <property name="pixbuf">../images/edu-vpn-logo.png</property>
+                <property name="pixbuf">share/eduvpn/images/edu-vpn-logo.png</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -77,7 +77,7 @@
                       <object class="GtkImage" id="settingsButton">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="pixbuf">../images/settings.png</property>
+                        <property name="pixbuf">share/eduvpn/images/settings.png</property>
                       </object>
                     </child>
                   </object>
@@ -96,7 +96,7 @@
                       <object class="GtkImage" id="helpButton">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="pixbuf">../images/question-icon.png</property>
+                        <property name="pixbuf">share/eduvpn/images/question-icon.png</property>
                       </object>
                     </child>
                   </object>
@@ -136,7 +136,7 @@
                       <object class="GtkImage" id="findServerImage">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="pixbuf">../images/institute.png</property>
+                        <property name="pixbuf">share/eduvpn/images/institute.png</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -259,7 +259,7 @@
                                   <object class="GtkImage">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="pixbuf">../images/institute-icon.png</property>
+                                    <property name="pixbuf">share/eduvpn/images/institute-icon.png</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -319,7 +319,7 @@
                                   <object class="GtkImage">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="pixbuf">../images/earth-icon.png</property>
+                                    <property name="pixbuf">share/eduvpn/images/earth-icon.png</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -391,7 +391,7 @@
                                   <object class="GtkImage">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="pixbuf">../images/server-icon.png</property>
+                                    <property name="pixbuf">share/eduvpn/images/server-icon.png</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -725,7 +725,7 @@
                   <object class="GtkImage" id="connectionStatusImage">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="pixbuf">../images/desktop-default.png</property>
+                    <property name="pixbuf">share/eduvpn/images/desktop-default.png</property>
                   </object>
                   <packing>
                     <property name="expand">True</property>

--- a/share/eduvpn/builder/mainwindow.ui
+++ b/share/eduvpn/builder/mainwindow.ui
@@ -36,7 +36,7 @@
                   <object class="GtkImage" id="backButton">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="pixbuf">share/eduvpn/images/back.png</property>
+                    <property name="pixbuf">../images/back.png</property>
                   </object>
                 </child>
               </object>
@@ -54,7 +54,7 @@
                 <property name="can_focus">False</property>
                 <property name="margin_left">10</property>
                 <property name="margin_right">10</property>
-                <property name="pixbuf">share/eduvpn/images/edu-vpn-logo.png</property>
+                <property name="pixbuf">../images/edu-vpn-logo.png</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -77,7 +77,7 @@
                       <object class="GtkImage" id="settingsButton">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="pixbuf">share/eduvpn/images/settings.png</property>
+                        <property name="pixbuf">../images/settings.png</property>
                       </object>
                     </child>
                   </object>
@@ -96,7 +96,7 @@
                       <object class="GtkImage" id="helpButton">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="pixbuf">share/eduvpn/images/question-icon.png</property>
+                        <property name="pixbuf">../images/question-icon.png</property>
                       </object>
                     </child>
                   </object>
@@ -136,7 +136,7 @@
                       <object class="GtkImage" id="findServerImage">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="pixbuf">share/eduvpn/images/institute.png</property>
+                        <property name="pixbuf">../images/institute.png</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -259,7 +259,7 @@
                                   <object class="GtkImage">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="pixbuf">share/eduvpn/images/institute-icon.png</property>
+                                    <property name="pixbuf">../images/institute-icon.png</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -319,7 +319,7 @@
                                   <object class="GtkImage">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="pixbuf">share/eduvpn/images/earth-icon.png</property>
+                                    <property name="pixbuf">../images/earth-icon.png</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -391,7 +391,7 @@
                                   <object class="GtkImage">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="pixbuf">share/eduvpn/images/server-icon.png</property>
+                                    <property name="pixbuf">../images/server-icon.png</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -725,7 +725,7 @@
                   <object class="GtkImage" id="connectionStatusImage">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="pixbuf">share/eduvpn/images/desktop-default.png</property>
+                    <property name="pixbuf">../images/desktop-default.png</property>
                   </object>
                   <packing>
                     <property name="expand">True</property>


### PR DESCRIPTION
This removes the call to `os.chdir()` as discussed in #423.