### PR TITLE
OAuth: Set oauth ready before webbrowser open

### DIFF
--- a/eduvpn/interface/event.py
+++ b/eduvpn/interface/event.py
@@ -50,8 +50,8 @@ def on_setup_oauth(app: Application, server: AnyServer):
         else:
             logger.warning(f"missing 'secure internet server' for {server!r}")
     logger.info(f"opening browser with {browser_url}")
-    webbrowser.open(browser_url)
     app.interface_transition_threadsafe('ready_for_oauth_setup', webserver)
+    webbrowser.open(browser_url)
 
 
 @run_in_background_thread('oauth-refresh')


### PR DESCRIPTION
Fixes #439 

This commit sets the `ready_for_oauth_setup` state before the browser is
opened. In certain browsers (e.g. palemoon) the `webbrowser.open` call
does not terminate after the url is opened, but instead stays alive
until the browser window is closed.

This results in an invalid state:
```
2022-02-07 11:27:14,529 - MainThread - ERROR - eduvpn.app - app.py:137 - invalid interface state transition: <OAuthSetupPending server=<InstituteAccessServer 'Radboud University'>> -> oauth_setup_success
```

We can test the difference in behaviour of `webbrowser.open` with:
```bash
BROWSER=firefox python -m webbrowser "google.com" (exits immediately)
BROWSER=palemoon python -m webbrowser "google.com" (waits up until closed)
BROWSER=chromium python -m webbrowser "google.com" (exits immediately or after ~5s timeout)
```

Signed-off-by: jwijenbergh <jeroenwijenbergh@protonmail.com>