### PR TITLE
Centos Docker: Use the vault archive

### DIFF
--- a/docker/pytest_centos_8.docker
+++ b/docker/pytest_centos_8.docker
@@ -1,5 +1,12 @@
 FROM centos:8
 
+# Centos 8 is EOL, use the vault archive
+# See https://techglimpse.com/failed-metadata-repo-appstream-centos-8/
+WORKDIR /etc/yum.repos.d/
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+RUN yum update -y
+
 RUN dnf install -y epel-release
 
 RUN dnf install -y \

--- a/docker/rpm_centos_8.docker
+++ b/docker/rpm_centos_8.docker
@@ -1,5 +1,12 @@
 FROM centos:8
 
+# Centos 8 is EOL, use the vault archive
+# See https://techglimpse.com/failed-metadata-repo-appstream-centos-8/
+WORKDIR /etc/yum.repos.d/
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+RUN yum update -y
+
 RUN yum install -y epel-release
 
 RUN yum install -y	\


### PR DESCRIPTION
Fixes part of #442

We can use Centos stream in a different PR. For now, we need to get the builds working again.

Centos 8 is EOL, to fix builds for now use the vault archive, see: https://techglimpse.com/failed-metadata-repo-appstream-centos-8/

Signed-off-by: jwijenbergh <jeroenwijenbergh@protonmail.com>