### PR TITLE
CI: Move from CentOS to CentOS stream8

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -16,13 +16,13 @@ jobs:
           - doc
           - pep8
           - pylama
-          - pytest_centos_8
+          - pytest_centos_stream8
           - pytest_debian_buster
           - pytest_debian_bullseye
           - pytest_fedora_35
           - pytest_ubuntu_bionic
           - pytest_ubuntu_focal
-          - rpm_centos_8
+          - rpm_centos_stream8
           - rpm_fedora_35
     steps:
       - name: Checkout

--- a/docker/pytest_centos_stream8.docker
+++ b/docker/pytest_centos_stream8.docker
@@ -1,11 +1,4 @@
-FROM centos:8
-
-# Centos 8 is EOL, use the vault archive
-# See https://techglimpse.com/failed-metadata-repo-appstream-centos-8/
-WORKDIR /etc/yum.repos.d/
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-RUN yum update -y
+FROM tgagor/centos:stream8
 
 RUN dnf install -y epel-release
 

--- a/docker/rpm_centos_stream8.docker
+++ b/docker/rpm_centos_stream8.docker
@@ -1,11 +1,4 @@
-FROM centos:8
-
-# Centos 8 is EOL, use the vault archive
-# See https://techglimpse.com/failed-metadata-repo-appstream-centos-8/
-WORKDIR /etc/yum.repos.d/
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-RUN yum update -y
+FROM tgagor/centos:stream8
 
 RUN yum install -y epel-release
 


### PR DESCRIPTION
Fixes #442 

This commit updates the docker images used in the CI to use CentOS
stream 8. This is because CentOS 8 is EOL.

Note that these are unofficial images as the official images do not support stream (yet).

Signed-off-by: jwijenbergh <jeroenwijenbergh@protonmail.com>