### PR TITLE
UI: Add a connection info expander

### DIFF
--- a/eduvpn/network.py
+++ b/eduvpn/network.py
@@ -3,19 +3,14 @@ import logging
 import enum
 from functools import partial
 from time import sleep
-from gettext import gettext
 from . import nm
 from . import settings
 from .state_machine import BaseState
 from .app import Application
 from .server import ConfiguredServer as Server
-from .utils import run_in_background_thread
+from .utils import run_in_background_thread, translated_property
 
 logger = logging.getLogger(__name__)
-
-
-def translated_property(text):
-    return property(lambda self: gettext(text))  # type: ignore
 
 
 class StatusImage(enum.Enum):

--- a/eduvpn/nm.py
+++ b/eduvpn/nm.py
@@ -44,6 +44,73 @@ def get_mainloop():
     return GLib.MainLoop()
 
 
+def get_iface() -> Optional[str]:
+    """
+    Get the interface as a string if there is a master device
+    """
+    client = get_client()
+    active_connection = client.get_primary_connection()
+    if not active_connection:
+        return None
+
+    master = active_connection.get_master()
+    if not master:
+        return None
+
+    return master.get_ip_iface()
+
+
+def get_ipv4() -> Optional[str]:
+    """
+    Get the ipv4 address as a string if there is one
+    """
+    client = get_client()
+    active_connection = client.get_primary_connection()
+    if not active_connection:
+        return None
+
+    ip4_config = active_connection.get_ip4_config()
+    addresses = ip4_config.get_addresses()
+    if not addresses:
+        return None
+    return addresses[0].get_address()
+
+
+def get_ipv6() -> Optional[str]:
+    """
+    Get the ipv6 address as a string if there is one
+    """
+    client = get_client()
+    active_connection = client.get_primary_connection()
+    if not active_connection:
+        return None
+
+    ip6_config = active_connection.get_ip6_config()
+    addresses = ip6_config.get_addresses()
+    if not addresses:
+        return None
+    return addresses[0].get_address()
+
+
+def get_timestamp() -> Optional[int]:
+    """
+    Get the timestamp the connection was last activated
+    """
+    client = get_client()
+    active_connection = client.get_primary_connection()
+    if not active_connection:
+        return None
+
+    connection = active_connection.get_connection()
+    if not connection:
+        return None
+
+    setting_connection = connection.get_settings()
+    if not setting_connection:
+        return None
+    return setting_connection[0].get_timestamp()
+
+
 def nm_available() -> bool:
     """
     check if Network Manager is available

--- a/eduvpn/ui/stats.py
+++ b/eduvpn/ui/stats.py
@@ -1,0 +1,145 @@
+import logging
+import time
+from datetime import timedelta
+from pathlib import Path
+from typing import Optional, TextIO
+
+from ..nm import get_iface, get_ipv4, get_ipv6, get_timestamp
+from ..utils import cache, get_human_readable_bytes, translated_property
+
+logger = logging.getLogger(__name__)
+
+LINUX_NET_FOLDER = Path("/sys/class/net")
+
+
+class NetworkStats:
+
+    default_text = translated_property("N/A")
+
+    # These properties define an LRU cache
+    # This cache is used so that we do not query these every second
+    @property  # type: ignore
+    @cache
+    def ipv4(self) -> str:
+        _ipv4 = get_ipv4()
+        if _ipv4 is None:
+            _ipv4 = self.default_text
+        return _ipv4
+
+    @property  # type: ignore
+    @cache
+    def ipv6(self) -> str:
+        _ipv6 = get_ipv6()
+        if _ipv6 is None:
+            _ipv6 = self.default_text
+        return _ipv6
+
+    @property  # type: ignore
+    @cache
+    def upload_file(self) -> Optional[TextIO]:
+        return self.open_file("tx_bytes")
+
+    @property  # type: ignore
+    @cache
+    def download_file(self) -> Optional[TextIO]:
+        return self.open_file("rx_bytes")
+
+    @property  # type: ignore
+    @cache
+    def start_bytes_upload(self) -> Optional[int]:
+        return self.get_file_bytes(self.upload_file)  # type: ignore
+
+    @property  # type: ignore
+    @cache
+    def start_bytes_download(self) -> Optional[int]:
+        return self.get_file_bytes(self.download_file)  # type: ignore
+
+    @property  # type: ignore
+    @cache
+    def iface(self) -> Optional[str]:
+        return get_iface()
+
+    @property  # type: ignore
+    @cache
+    def timestamp(self) -> Optional[int]:
+        return get_timestamp()
+
+    @property
+    def download(self) -> str:
+        """
+        Get the download as a human readable string
+        """
+        file_bytes_download = self.get_file_bytes(self.download_file)  # type: ignore
+        if file_bytes_download is None:
+            return self.default_text
+        if file_bytes_download <= self.start_bytes_download:  # type: ignore
+            return get_human_readable_bytes(0)
+        return get_human_readable_bytes(file_bytes_download - self.start_bytes_download)  # type: ignore
+
+    @property
+    def upload(self) -> str:
+        """
+        Get the upload as a human readable string
+        """
+        file_bytes_upload = self.get_file_bytes(self.upload_file)  # type: ignore
+        if file_bytes_upload is None:
+            return self.default_text
+        if file_bytes_upload <= self.start_bytes_upload:  # type: ignore
+            return get_human_readable_bytes(0)
+        return get_human_readable_bytes(file_bytes_upload - self.start_bytes_upload)  # type:ignore
+
+    @property
+    def duration(self) -> str:
+        """
+        Get the duration of the connection, in "HH:MM:SS"
+        """
+        if self.timestamp is None:
+            logger.warning("Network Stats: failed to get timestamp")
+            return self.default_text
+        now_unix_seconds = int(time.time())
+        duration = now_unix_seconds - self.timestamp  # type: ignore
+        return str(timedelta(seconds=duration))
+
+    def open_file(self, filename: str) -> Optional[TextIO]:
+        """
+        Helper function to open a statistics network file
+        """
+        if not self.iface:
+            logger.warning(f"Network Stats: {filename}, failed to get interface")
+            return None
+        filepath = LINUX_NET_FOLDER / self.iface / "statistics" / filename  # type: ignore
+        if not filepath.is_file():
+            logger.warning(f"Network Stats: {filepath} is not a file")
+            return None
+        return open(filepath, "r")
+
+    def get_file_bytes(self, filehandler: Optional[TextIO]) -> Optional[int]:
+        """
+        Helper function to get a statistics file to calculate the total data transfer
+        """
+        # If the interface is not set
+        # or the file is not present, we cannot get the stat
+        if not self.iface:
+            # Warning was already shown
+            return None
+        if not filehandler:
+            # Warning was already shown
+            return None
+
+        # Get the statistic from the file
+        # and go to the beginning
+        try:
+            stat = int(filehandler.readline())
+        except ValueError:
+            stat = 0
+        filehandler.seek(0)
+        return stat
+
+    def cleanup(self):
+        """
+        Cleanup the network stats by closing the files
+        """
+        if self.download_file:
+            self.download_file.close()
+        if self.upload_file:
+            self.upload_file.close()

--- a/eduvpn/ui/ui.py
+++ b/eduvpn/ui/ui.py
@@ -29,6 +29,7 @@ from ..utils import (
     get_prefix, run_in_main_gtk_thread, run_periodically, cancel_at_context_end)
 from . import search
 from .utils import show_ui_component, link_markup, show_error_dialog
+from .stats import NetworkStats
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +91,7 @@ class EduVpnGtkWindow(Gtk.ApplicationWindow):
             "on_search_changed": self.on_search_changed,
             "on_search_activate": self.on_search_activate,
             "on_switch_connection_state": self.on_switch_connection_state,
+            "on_toggle_connection_info": self.on_toggle_connection_info,
             "on_profile_selection_changed": self.on_profile_selection_changed,
             "on_location_selection_changed": self.on_location_selection_changed,
             "on_acknowledge_error": self.on_acknowledge_error,
@@ -134,6 +136,14 @@ class EduVpnGtkWindow(Gtk.ApplicationWindow):
         self.connection_status_label = builder.get_object('connectionStatusLabel')
         self.connection_session_label = builder.get_object('connectionSessionLabel')
         self.connection_switch = builder.get_object('connectionSwitch')
+        self.connection_info_expander = builder.get_object('connectionInfoExpander')
+        self.connection_info_duration = builder.get_object('connectionInfoDurationText')
+        self.connection_info_downloaded = builder.get_object('connectionInfoDownloadedText')
+        self.connection_info_uploaded = builder.get_object('connectionInfoUploadedText')
+        self.connection_info_ipv4address = builder.get_object('connectionInfoIpv4AddressText')
+        self.connection_info_ipv6address = builder.get_object('connectionInfoIpv6AddressText')
+        self.connection_info_thread_cancel = None
+        self.connection_info_stats = None
 
         self.server_image = builder.get_object('serverImage')
         self.server_label = builder.get_object('serverLabel')
@@ -493,6 +503,12 @@ class EduVpnGtkWindow(Gtk.ApplicationWindow):
     def exit_ConfiguringConnection(self, old_state, new_state):
         self.hide_loading_page()
 
+    @transition_edge_callback(ENTER, network_state.ConnectedState)
+    def enter_ConnectedState(self, old_state, new_state):
+        is_expanded = self.connection_info_expander.get_expanded()
+        if is_expanded:
+            self.start_connection_info()
+
     @transition_edge_callback(ENTER, interface_state.ConnectionStatus)
     def enter_ConnectionStatus(self, old_state, new_state):
         self.show_page(self.connection_page)
@@ -502,6 +518,7 @@ class EduVpnGtkWindow(Gtk.ApplicationWindow):
     @transition_edge_callback(EXIT, interface_state.ConnectionStatus)
     def exit_ConnectionStatus(self, old_state, new_state):
         self.hide_page(self.connection_page)
+        self.stop_connection_info()
 
     @transition_level_callback(interface_state.ConnectionStatus)
     def context_ConnectionStatus(self, state):
@@ -510,6 +527,10 @@ class EduVpnGtkWindow(Gtk.ApplicationWindow):
             UPDATE_EXIPRY_INTERVAL,
             'update-validity',
         ))
+
+    @transition_edge_callback(ENTER, network_state.DisconnectedState)
+    def enter_DisconnectedState(self, old_state, new_state):
+        self.stop_connection_info()
 
     @transition_edge_callback(ENTER, interface_state.ErrorState)
     def enter_ErrorState(self, old_state, new_state):
@@ -594,6 +615,50 @@ class EduVpnGtkWindow(Gtk.ApplicationWindow):
             else:
                 self.app.interface_transition('deactivate_connection')
         return True
+
+    def stop_connection_info(self):
+        if self.connection_info_thread_cancel:
+            self.connection_info_thread_cancel()
+            self.connection_info_thread = None
+
+        if self.connection_info_stats:
+            self.connection_info_stats.cleanup()
+            self.connection_info_stats = None
+
+    def start_connection_info(self):
+        if not self.app.network_state.has_transition('disconnect'):
+            logger.info("Connection Info: VPN is not active")
+            return
+
+        def update_connection_info_callback():
+            assert self.connection_info_stats
+            download = self.connection_info_stats.download
+            upload = self.connection_info_stats.upload
+            ipv4 = self.connection_info_stats.ipv4
+            ipv6 = self.connection_info_stats.ipv6
+            duration = self.connection_info_stats.duration
+            self.connection_info_downloaded.set_text(download)
+            self.connection_info_uploaded.set_text(upload)
+            self.connection_info_ipv4address.set_text(ipv4)
+            self.connection_info_ipv6address.set_text(ipv6)
+            self.connection_info_duration.set_text(duration)
+
+        if not self.connection_info_stats:
+            self.connection_info_stats = NetworkStats()
+
+        # Run every second in the background
+        self.connection_info_thread_cancel = run_periodically(
+            update_connection_info_callback, 1
+        )
+
+    def on_toggle_connection_info(self, _):
+        logger.debug("clicked on connection info")
+        was_expanded = self.connection_info_expander.get_expanded()
+
+        if not was_expanded:
+            self.start_connection_info()
+        else:
+            self.stop_connection_info()
 
     def on_profile_selection_changed(self, selection):
         logger.debug("selected profile")

--- a/eduvpn/utils.py
+++ b/eduvpn/utils.py
@@ -4,6 +4,7 @@ import threading
 from datetime import datetime
 from email.utils import parsedate_to_datetime
 from functools import lru_cache, partial, wraps
+from gettext import gettext
 from logging import getLogger
 from os import path, environ
 from sys import prefix
@@ -169,3 +170,25 @@ def parse_http_date_header(date: str) -> datetime:
 
 
 parse_http_expires_header = parse_http_date_header
+
+
+def get_human_readable_bytes(total_bytes: int) -> str:
+    """
+    Helper function to calculate the human readable bytes.
+    E.g. B, kB, MB, GB, TB.
+    """
+    suffix = ""
+    hr_bytes = float(total_bytes)
+    for suffix in ["B", "kB", "MB", "GB", "TB"]:
+        if hr_bytes < 1024.0:
+            break
+        if suffix != "TB":
+            hr_bytes /= 1024.0
+
+    if suffix == "B":
+        return f"{int(hr_bytes)} {suffix}"
+    return f"{hr_bytes:.2f} {suffix}"
+
+
+def translated_property(text):
+    return property(lambda self: gettext(text))  # type: ignore

--- a/share/eduvpn/builder/mainwindow.ui
+++ b/share/eduvpn/builder/mainwindow.ui
@@ -1,41 +1,56 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <!-- interface-local-resource-path ../images -->
   <object class="EduVpnGtkWindow" id="eduvpn">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">eduVPN</property>
-    <property name="default_width">440</property>
-    <property name="default_height">597</property>
+    <property name="default-width">440</property>
+    <property name="default-height">597</property>
     <property name="icon">../../icons/hicolor/128x128/apps/org.eduvpn.client.png</property>
-    <property name="has_resize_grip">True</property>
-    <property name="show_menubar">False</property>
+    <property name="has-resize-grip">True</property>
     <signal name="delete-event" handler="on_close_window" swapped="no"/>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="margin_left">20</property>
-        <property name="margin_right">20</property>
-        <property name="margin_top">16</property>
-        <property name="margin_bottom">20</property>
+        <property name="can-focus">False</property>
+        <property name="margin-left">20</property>
+        <property name="margin-right">20</property>
+        <property name="margin-top">16</property>
+        <property name="margin-bottom">20</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox">
-            <property name="height_request">36</property>
+            <property name="height-request">36</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_bottom">16</property>
+            <property name="can-focus">False</property>
+            <property name="margin-bottom">16</property>
+            <child type="center">
+              <object class="GtkImage" id="appLogo">
+                <property name="width-request">120</property>
+                <property name="height-request">36</property>
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">10</property>
+                <property name="margin-right">10</property>
+                <property name="pixbuf">../images/edu-vpn-logo.png</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
             <child>
               <object class="GtkEventBox" id="backButtonEventBox">
-                <property name="width_request">30</property>
-                <property name="can_focus">False</property>
+                <property name="width-request">30</property>
+                <property name="can-focus">False</property>
                 <signal name="button-press-event" handler="on_go_back" swapped="no"/>
                 <child>
                   <object class="GtkImage" id="backButton">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="pixbuf">../images/back.png</property>
                   </object>
                 </child>
@@ -46,37 +61,21 @@
                 <property name="position">0</property>
               </packing>
             </child>
-            <child type="center">
-              <object class="GtkImage" id="appLogo">
-                <property name="width_request">120</property>
-                <property name="height_request">36</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">10</property>
-                <property name="margin_right">10</property>
-                <property name="pixbuf">../images/edu-vpn-logo.png</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="halign">end</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkEventBox">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <signal name="button-press-event" handler="on_configure_settings" swapped="no"/>
                     <child>
                       <object class="GtkImage" id="settingsButton">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="pixbuf">../images/settings.png</property>
                       </object>
                     </child>
@@ -90,12 +89,12 @@
                 <child>
                   <object class="GtkEventBox">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <signal name="button-release-event" handler="on_get_help" swapped="no"/>
                     <child>
                       <object class="GtkImage" id="helpButton">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="pixbuf">../images/question-icon.png</property>
                       </object>
                     </child>
@@ -108,34 +107,38 @@
                 </child>
               </object>
               <packing>
-                <property name="pack_type">end</property>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack-type">end</property>
                 <property name="position">2</property>
               </packing>
             </child>
           </object>
           <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkStack" id="pageStack">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkBox" id="findServerPage">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkBox" id="findServerSearchForm">
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">10</property>
                     <child>
                       <object class="GtkImage" id="findServerImage">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="pixbuf">../images/institute.png</property>
                       </object>
                       <packing>
@@ -147,7 +150,7 @@
                     <child>
                       <object class="GtkLabel" id="findServerLabel">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Find your institute</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
@@ -162,11 +165,11 @@
                     <child>
                       <object class="GtkSearchEntry" id="findServerSearchInput">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="primary_icon_name">edit-find-symbolic</property>
-                        <property name="primary_icon_activatable">False</property>
-                        <property name="primary_icon_sensitive">False</property>
-                        <property name="placeholder_text" translatable="yes">Search for your institute...</property>
+                        <property name="can-focus">True</property>
+                        <property name="primary-icon-name">edit-find-symbolic</property>
+                        <property name="primary-icon-activatable">False</property>
+                        <property name="primary-icon-sensitive">False</property>
+                        <property name="placeholder-text" translatable="yes">Search for your institute...</property>
                         <signal name="activate" handler="on_search_activate" swapped="no"/>
                         <signal name="search-changed" handler="on_search_changed" swapped="no"/>
                       </object>
@@ -185,14 +188,14 @@
                 </child>
                 <child>
                   <object class="GtkBox" id="addOtherServerRow">
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkButton" id="addOtherServerButton">
                         <property name="label" translatable="yes">Add Other Server</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
                         <property name="halign">center</property>
                         <property name="valign">center</property>
                         <signal name="clicked" handler="on_add_other_server" swapped="no"/>
@@ -212,14 +215,14 @@
                 </child>
                 <child>
                   <object class="GtkBox" id="addCustomServerRow">
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkButton" id="addCustomServerButton">
                         <property name="label" translatable="yes">Add Server</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
                         <property name="halign">center</property>
                         <property name="valign">center</property>
                         <signal name="clicked" handler="on_add_custom_server" swapped="no"/>
@@ -239,26 +242,26 @@
                 </child>
                 <child>
                   <object class="GtkScrolledWindow" id="serverListContainer">
-                    <property name="can_focus">True</property>
-                    <property name="shadow_type">in</property>
+                    <property name="can-focus">True</property>
+                    <property name="shadow-type">in</property>
                     <child>
                       <object class="GtkViewport">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <child>
                           <object class="GtkBox">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <property name="spacing">10</property>
                             <child>
                               <object class="GtkBox" id="instituteAccessHeader">
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="spacing">15</property>
                                 <child>
                                   <object class="GtkImage">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="pixbuf">../images/institute-icon.png</property>
                                   </object>
                                   <packing>
@@ -270,7 +273,7 @@
                                 <child>
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Institute Access</property>
                                     <attributes>
                                       <attribute name="weight" value="bold"/>
@@ -291,13 +294,13 @@
                             </child>
                             <child>
                               <object class="GtkTreeView" id="instituteTreeView">
-                                <property name="can_focus">True</property>
+                                <property name="can-focus">True</property>
                                 <property name="hexpand">True</property>
                                 <property name="vexpand">True</property>
-                                <property name="headers_visible">False</property>
-                                <property name="enable_search">False</property>
-                                <property name="search_column">0</property>
-                                <property name="enable_grid_lines">horizontal</property>
+                                <property name="headers-visible">False</property>
+                                <property name="enable-search">False</property>
+                                <property name="search-column">0</property>
+                                <property name="enable-grid-lines">horizontal</property>
                                 <child internal-child="selection">
                                   <object class="GtkTreeSelection">
                                     <signal name="changed" handler="on_select_server" swapped="no"/>
@@ -313,12 +316,12 @@
                             <child>
                               <object class="GtkBox" id="secureInternetHeader">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="spacing">15</property>
                                 <child>
                                   <object class="GtkImage">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="pixbuf">../images/earth-icon.png</property>
                                   </object>
                                   <packing>
@@ -330,7 +333,7 @@
                                 <child>
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Secure Internet</property>
                                     <attributes>
                                       <attribute name="weight" value="bold"/>
@@ -342,21 +345,21 @@
                                     <property name="position">1</property>
                                   </packing>
                                 </child>
-  				<!-- See https://github.com/eduvpn/python-eduvpn-client/issues/333 -->
-				<!-- <child> -->
-                                <!--   <object class="GtkButton" id="changeLocationButton"> -->
-                                <!--     <property name="label" translatable="yes">Change Location</property> -->
-                                <!--     <property name="visible">True</property> -->
-                                <!--     <property name="can_focus">True</property> -->
-                                <!--     <property name="receives_default">True</property> -->
-                                <!--   </object> -->
-                                <!--   <packing> -->
-                                <!--     <property name="expand">False</property> -->
-                                <!--     <property name="fill">True</property> -->
-                                <!--     <property name="pack_type">end</property> -->
-                                <!--     <property name="position">2</property> -->
-                                <!--   </packing> -->
-                                <!-- </child> -->
+                              <!-- See https://github.com/eduvpn/python-eduvpn-client/issues/333 -->
+                              <!-- <child> -->
+                              <!--   <object class="GtkButton" id="changeLocationButton"> -->
+                              <!--     <property name="label" translatable="yes">Change Location</property> -->
+                              <!--     <property name="visible">True</property> -->
+                              <!--     <property name="can_focus">True</property> -->
+                              <!--     <property name="receives_default">True</property> -->
+                              <!--   </object> -->
+                              <!--   <packing> -->
+                              <!--     <property name="expand">False</property> -->
+                              <!--     <property name="fill">True</property> -->
+                              <!--     <property name="pack_type">end</property> -->
+                              <!--     <property name="position">2</property> -->
+                              <!--   </packing> -->
+                              <!-- </child> -->
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -366,11 +369,11 @@
                             </child>
                             <child>
                               <object class="GtkTreeView" id="secureInternetTreeView">
-                                <property name="can_focus">True</property>
-                                <property name="headers_visible">False</property>
-                                <property name="enable_search">False</property>
-                                <property name="search_column">0</property>
-                                <property name="enable_grid_lines">horizontal</property>
+                                <property name="can-focus">True</property>
+                                <property name="headers-visible">False</property>
+                                <property name="enable-search">False</property>
+                                <property name="search-column">0</property>
+                                <property name="enable-grid-lines">horizontal</property>
                                 <child internal-child="selection">
                                   <object class="GtkTreeSelection">
                                     <signal name="changed" handler="on_select_server" swapped="no"/>
@@ -386,12 +389,12 @@
                             <child>
                               <object class="GtkBox" id="otherServersHeader">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="spacing">15</property>
                                 <child>
                                   <object class="GtkImage">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="pixbuf">../images/server-icon.png</property>
                                   </object>
                                   <packing>
@@ -403,7 +406,7 @@
                                 <child>
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Other Servers</property>
                                     <attributes>
                                       <attribute name="weight" value="bold"/>
@@ -424,11 +427,11 @@
                             </child>
                             <child>
                               <object class="GtkTreeView" id="otherServersTreeView">
-                                <property name="can_focus">True</property>
-                                <property name="headers_visible">False</property>
-                                <property name="enable_search">False</property>
-                                <property name="search_column">0</property>
-                                <property name="enable_grid_lines">horizontal</property>
+                                <property name="can-focus">True</property>
+                                <property name="headers-visible">False</property>
+                                <property name="enable-search">False</property>
+                                <property name="search-column">0</property>
+                                <property name="enable-grid-lines">horizontal</property>
                                 <child internal-child="selection">
                                   <object class="GtkTreeSelection">
                                     <signal name="changed" handler="on_select_server" swapped="no"/>
@@ -460,14 +463,14 @@
             <child>
               <object class="GtkBox" id="openBrowserPage">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="valign">center</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Authorization required</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
@@ -482,7 +485,7 @@
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">This app needs authorization and has opened your webbrowser. It will proceed when you have completed the authorization</property>
                     <property name="justify">center</property>
                     <property name="wrap">True</property>
@@ -495,9 +498,9 @@
                 </child>
                 <child>
                   <object class="GtkSpinner">
-                    <property name="height_request">30</property>
+                    <property name="height-request">30</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="active">True</property>
                   </object>
                   <packing>
@@ -510,8 +513,8 @@
                   <object class="GtkButton" id="cancelBrowserButton">
                     <property name="label" translatable="yes">Cancel</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
                     <property name="halign">center</property>
                     <signal name="clicked" handler="on_cancel_oauth_setup" swapped="no"/>
                   </object>
@@ -529,13 +532,13 @@
             <child>
               <object class="GtkBox" id="chooseLocationPage">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkLabel" id="chooseLocationLabel">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Please choose a location</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
@@ -550,13 +553,13 @@
                 <child>
                   <object class="GtkTreeView" id="locationTreeView">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="hexpand">True</property>
                     <property name="vexpand">True</property>
-                    <property name="headers_visible">False</property>
-                    <property name="enable_search">False</property>
-                    <property name="search_column">0</property>
-                    <property name="enable_grid_lines">horizontal</property>
+                    <property name="headers-visible">False</property>
+                    <property name="enable-search">False</property>
+                    <property name="search-column">0</property>
+                    <property name="enable-grid-lines">horizontal</property>
                     <child internal-child="selection">
                       <object class="GtkTreeSelection">
                         <signal name="changed" handler="on_location_selection_changed" swapped="no"/>
@@ -577,13 +580,13 @@
             <child>
               <object class="GtkBox" id="chooseProfilePage">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkLabel" id="chooseProfileLabel">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Please choose a profile</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
@@ -598,13 +601,13 @@
                 <child>
                   <object class="GtkTreeView" id="profileTreeView">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="hexpand">True</property>
                     <property name="vexpand">True</property>
-                    <property name="headers_visible">False</property>
-                    <property name="enable_search">False</property>
-                    <property name="search_column">0</property>
-                    <property name="enable_grid_lines">horizontal</property>
+                    <property name="headers-visible">False</property>
+                    <property name="enable-search">False</property>
+                    <property name="search-column">0</property>
+                    <property name="enable-grid-lines">horizontal</property>
                     <child internal-child="selection">
                       <object class="GtkTreeSelection">
                         <signal name="changed" handler="on_profile_selection_changed" swapped="no"/>
@@ -623,69 +626,17 @@
               </packing>
             </child>
             <child>
-              <object class="GtkBox" id="loadingPage">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="valign">center</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">10</property>
-                <child>
-                  <object class="GtkLabel" id="loadingTitle">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Loading</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="loadingMessage">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Please wait</property>
-                    <property name="justify">center</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSpinner">
-                    <property name="height_request">30</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="active">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">3</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="position">4</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkBox" id="connectionPage">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="valign">center</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">10</property>
+                <property name="baseline-position">bottom</property>
                 <child>
                   <object class="GtkImage" id="serverImage">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="stock">gtk-missing-image</property>
                   </object>
                   <packing>
@@ -697,7 +648,7 @@
                 <child>
                   <object class="GtkLabel" id="serverLabel">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Server Label</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
@@ -712,7 +663,7 @@
                 <child>
                   <object class="GtkLabel" id="supportLabel">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Support:</property>
                     <property name="selectable">True</property>
                   </object>
@@ -725,7 +676,7 @@
                 <child>
                   <object class="GtkImage" id="connectionStatusImage">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="pixbuf">../images/desktop-default.png</property>
                   </object>
                   <packing>
@@ -737,7 +688,7 @@
                 <child>
                   <object class="GtkLabel" id="connectionStatusLabel">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Not connected</property>
                   </object>
                   <packing>
@@ -749,7 +700,7 @@
                 <child>
                   <object class="GtkLabel" id="connectionSessionLabel">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -760,7 +711,7 @@
                 <child>
                   <object class="GtkSwitch" id="connectionSwitch">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="halign">center</property>
                     <signal name="state-set" handler="on_switch_connection_state" swapped="no"/>
                   </object>
@@ -774,16 +725,296 @@
                   <object class="GtkButton" id="renewSessionButton">
                     <property name="label" translatable="yes">Renew Session</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
                     <property name="halign">center</property>
-                    <property name="image_position">top</property>
+                    <property name="image-position">top</property>
                     <signal name="clicked" handler="on_renew_session_clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">7</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkExpander" id="connectionInfoExpander">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="halign">center</property>
+                    <property name="margin-top">45</property>
+                    <signal name="activate" handler="on_toggle_connection_info" swapped="no"/>
+                    <child>
+                      <object class="GtkFrame">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-top">10</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">etched-out</property>
+                        <child>
+                          <object class="GtkAlignment">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
+                            <child>
+                              <!-- n-columns=4 n-rows=5 -->
+                              <object class="GtkGrid">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="hexpand">True</property>
+                                <property name="row-spacing">3</property>
+                                <property name="column-spacing">15</property>
+                                <property name="row-homogeneous">True</property>
+                                <property name="column-homogeneous">True</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="label" translatable="yes">Duration</property>
+                                    <attributes>
+                                      <attribute name="weight" value="semibold"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="connectionInfoDurationText">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="label" translatable="yes">N/A</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="label" translatable="yes">Downloaded</property>
+                                    <attributes>
+                                      <attribute name="weight" value="semibold"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="connectionInfoDownloadedText">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="label" translatable="yes">N/A</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="label" translatable="yes">Uploaded</property>
+                                    <attributes>
+                                      <attribute name="weight" value="semibold"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">2</property>
+                                    <property name="top-attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="connectionInfoUploadedText">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="label" translatable="yes">N/A</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">3</property>
+                                    <property name="top-attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="label" translatable="yes">IPv4 Address</property>
+                                    <attributes>
+                                      <attribute name="weight" value="semibold"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">3</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="label" translatable="yes">IPv6 Address</property>
+                                    <attributes>
+                                      <attribute name="weight" value="semibold"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">2</property>
+                                    <property name="top-attach">3</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="connectionInfoIpv4AddressText">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="label" translatable="yes">N/A</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">4</property>
+                                    <property name="width">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="connectionInfoIpv6AddressText">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="label" translatable="yes">N/A</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">2</property>
+                                    <property name="top-attach">4</property>
+                                    <property name="width">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child type="label_item">
+                          <placeholder/>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Show connection info</property>
+                        <attributes>
+                          <attribute name="scale" value="1.3"/>
+                        </attributes>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">8</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="position">4</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="loadingPage">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="valign">center</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">10</property>
+                <child>
+                  <object class="GtkLabel" id="loadingTitle">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Loading</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="loadingMessage">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Please wait</property>
+                    <property name="justify">center</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinner">
+                    <property name="height-request">30</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="active">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
               </object>
@@ -794,14 +1025,14 @@
             <child>
               <object class="GtkBox" id="errorPage">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="valign">center</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Error</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
@@ -816,7 +1047,7 @@
                 <child>
                   <object class="GtkLabel" id="errorText">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">General failure, please quit</property>
                     <property name="justify">center</property>
                     <property name="wrap">True</property>
@@ -831,8 +1062,8 @@
                   <object class="GtkButton" id="errorAcknowledgeButton">
                     <property name="label" translatable="yes">Ok</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
                     <property name="halign">center</property>
                     <signal name="clicked" handler="on_acknowledge_error" swapped="no"/>
                   </object>
@@ -850,13 +1081,13 @@
             <child>
               <object class="GtkBox" id="settingsPage">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="valign">start</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Settings</property>
                   </object>
                   <packing>
@@ -868,11 +1099,11 @@
                 <child>
                   <object class="GtkBox">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes">Force TCP</property>
                       </object>
@@ -885,7 +1116,7 @@
                     <child>
                       <object class="GtkSwitch" id="settingConfigForceTCP">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="halign">end</property>
                         <property name="hexpand">True</property>
                         <signal name="state-set" handler="on_config_force_tcp" swapped="no"/>

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,102 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from eduvpn.ui import stats
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+MOCK_IFACE = "mock"
+
+
+def write_temp_stats_file(directory: Path, filename: str, total_bytes: int):
+    f = open(directory / filename, "w")
+    f.write(str(total_bytes))
+    f.close()
+
+
+def try_open(path: Path):
+    if not path.is_file():
+        return None
+    return open(path, "r")
+
+
+class TestStats(TestCase):
+    @patch("eduvpn.ui.stats.NetworkStats.iface", MOCK_IFACE)
+    def test_download(self):
+        with TemporaryDirectory() as tempdir:
+            # Create test data in the wanted files
+            # Use the tempdir so it is cleaned up later
+            values = [0, 37, 6166746255814, -43]
+            filenames = [
+                "rx_bytes",
+                "rx_bytes_increased",
+                "rx_bytes_increased_big",
+                "rx_bytes_decreased",
+            ]
+            for index, value in enumerate(values):
+                write_temp_stats_file(Path(tempdir), filenames[index], value)
+
+            # Create the class instance
+            class_ = stats.NetworkStats()
+
+            # Add a file that does not exist
+            filenames += ["idonotexist"]
+
+            # For the expected values we want the human readable string
+            # The last two are special
+            #   - 0 B because the value has decreased
+            #   - default text because the file does not exist
+            expected_values = ["0 B", "37 B", "5.61 TB", "0 B", class_.default_text]
+
+            # Loop over the files,
+            # patch it and check if the expected value holds
+            class_ = stats.NetworkStats()
+            for index, filename in enumerate(filenames):
+                location = Path(tempdir) / filename
+                file_ = try_open(location)
+                with patch("eduvpn.ui.stats.NetworkStats.download_file", file_):
+                    self.assertEqual(class_.download, expected_values[index])
+                    class_.cleanup()
+
+    @patch("eduvpn.ui.stats.NetworkStats.iface", MOCK_IFACE)
+    def test_upload(self):
+        with TemporaryDirectory() as tempdir:
+            # Create test data in the wanted files
+            # Use the tempdir so it is cleaned up later
+            values = [0, 1024, 237823782378, -47]
+            filenames = [
+                "tx_bytes",
+                "tx_bytes_increased",
+                "tx_bytes_increased_big",
+                "tx_bytes_decreased",
+            ]
+            for index, value in enumerate(values):
+                write_temp_stats_file(Path(tempdir), filenames[index], value)
+
+            # Create the class instance
+            class_ = stats.NetworkStats()
+
+            # Add a file that does not exist
+            filenames += ["idonotexist"]
+
+            # For the expected values we want the human readable string
+            # The last two are special
+            #   - 0 B because the value has decreased
+            #   - default text because the file does not exist
+            expected_values = [
+                "0 B",
+                "1.00 kB",
+                "221.49 GB",
+                "0 B",
+                class_.default_text,
+            ]
+
+            # Loop over the files,
+            # patch it and check if the expected value holds
+            for index, filename in enumerate(filenames):
+                location = Path(tempdir) / filename
+                file_ = try_open(location)
+                with patch("eduvpn.ui.stats.NetworkStats.upload_file", file_):
+                    self.assertEqual(class_.upload, expected_values[index])
+                    class_.cleanup()


### PR DESCRIPTION
Fixes #248 

This commit adds a connection info expander to the UI.

Uses the NM api for querying, except where I could not find any
functions (e.g. rx and tx bytes, which are gathered from standard file
locations).

If it cannot find the data, as this is not foolproof, it will set it
to N/A, the application will keep working.

Note that glade changed the property names from `_` to `-`, but this
still works on the VMS. Apparently `_` are an old format that is not
used any more in glade.

Signed-off-by: jwijenbergh <jeroenwijenbergh@protonmail.com>