### PR TITLE
Fix issue #462

### DIFF
--- a/eduvpn/storage.py
+++ b/eduvpn/storage.py
@@ -89,6 +89,9 @@ Metadata = Tuple[OAuth2Token, str, str, str, str, str, str, str, str, Optional[d
 
 def serialize_datetime(dt: datetime) -> str:
     assert dt.tzinfo is not None
+    if not hasattr(datetime, 'fromisoformat'):
+        # Python < 3.7.
+        dt = dt.astimezone(timezone.utc)
     return dt.isoformat()
 
 
@@ -102,6 +105,9 @@ def deserialize_datetime(value: str) -> datetime:
             format += '.%f'
         if '+' in value or value.count('-') > 2:
             format += '%z'
+            if value[-3] == ':':
+                # Fix issue #462; Python3.6 does not accept the colon (bpo-31800).
+                value = value[:-3] + value[-2:]
         dt = datetime.strptime(value, format)
     # NOTE: Older versions stored session validities
     #       as they appeared on the certificate; without a timezone.

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,40 @@
+from unittest import TestCase
+from datetime import datetime, timezone
+from eduvpn.storage import serialize_datetime, deserialize_datetime
+
+
+utc = timezone.utc
+
+
+class DateTimeSerializationTests(TestCase):
+    def test_serialize_datetime(self):
+        self.assertEqual(
+            serialize_datetime(datetime(2022, 1, 3, 13, 46, 29, 0, utc)),
+            '2022-01-03T13:46:29+00:00',
+        )
+
+    def test_deserialize_datetime(self):
+        self.assertEqual(
+            deserialize_datetime('2022-01-03T13:46:29'),
+            datetime(2022, 1, 3, 13, 46, 29, 0, utc),
+        )
+        self.assertEqual(
+            deserialize_datetime('2022-01-03T13:46:29.123456'),
+            datetime(2022, 1, 3, 13, 46, 29, 123456, utc),
+        )
+
+        self.assertEqual(
+            deserialize_datetime('2022-01-03T13:46:29+00:00'),
+            datetime(2022, 1, 3, 13, 46, 29, 0, utc),
+        )
+        self.assertEqual(
+            deserialize_datetime('2022-01-03T13:46:29-00:00'),
+            datetime(2022, 1, 3, 13, 46, 29, 0, utc),
+        )
+
+    def test_serialize_roundtrip(self):
+        dt = datetime.now(timezone.utc)
+        self.assertEqual(
+            deserialize_datetime(serialize_datetime(dt)),
+            dt,
+        )


### PR DESCRIPTION
Unfortunately, the issue only happens on Python 3.6 which is EOL as of this year.
I prefer to keep datetimes timezone-aware, we can get rid of these fixes when we remove 3.6 support.