### PR TITLE
Fix issue #470

### DIFF
--- a/eduvpn/nm.py
+++ b/eduvpn/nm.py
@@ -253,7 +253,7 @@ def save_connection_with_config(client: 'NM.Client',
                                 certificate,
                                 callback=None,
                                 ):
-    ovpn = Ovpn(config)
+    ovpn = Ovpn.parse(config)
     settings = Configuration.load()
     if settings.force_tcp:
         ovpn.force_tcp()


### PR DESCRIPTION
During the fix in ccc7319212e2c437d0ae78c8e35f75932b506f42 the `Ovpn.write` method was rewritten to allow a config that is a list. The config list is generated by `Ovpn.parse`, which must be used instead of the constructor.

This was tested from commandline with `eduvpn-cli configure`.

This fixes #470 