### PR TITLE
Wireguard: Disable autoconnect to match OpenVPN behaviour

### DIFF
--- a/eduvpn/nm.py
+++ b/eduvpn/nm.py
@@ -384,6 +384,7 @@ def start_wireguard_connection(
 
     profile = NM.SimpleConnection.new()
     s_con = NM.SettingConnection.new()
+    s_con.set_property(NM.DEVICE_AUTOCONNECT, False)
     s_con.set_property(NM.SETTING_CONNECTION_ID, "eduvpn-wireguard")
     s_con.set_property(NM.SETTING_CONNECTION_TYPE, "wireguard")
     s_con.set_property(NM.SETTING_CONNECTION_UUID, str(uuid.uuid4()))


### PR DESCRIPTION
OpenVPN has autoconnect enabled, however autoconnect is not used for VPN profiles, see https://lazka.github.io/pgi-docs/#NM-1.0/classes/SettingConnection.html#NM.SettingConnection.props.autoconnect

This means that for OpenVPN, when disabling the VPN in the client and then rebooting, networkmanager will not enable the vpn connection. However, for wireguard right now it will re-enable the vpn even though the user has said to disconnect from it (because wireguard is not managed as a VPN profile by NM). This simply disables autoconnect so that networkmanager doesn't force it to reconnect when the machine has e.g. rebooted.

Reported by @fkooman 