### PR TITLE
Stats: Fix duration weirdness

### DIFF
--- a/eduvpn/nm.py
+++ b/eduvpn/nm.py
@@ -176,12 +176,11 @@ def get_timestamp() -> Optional[int]:
     """
     Get the timestamp the connection was last activated
     """
-    client = get_client()
-    active_connection = client.get_primary_connection()
-    if not active_connection:
+    uuid = get_uuid()
+    if uuid is None:
         return None
-
-    connection = active_connection.get_connection()
+    client = get_client()
+    connection = client.get_connection_by_uuid(uuid)
     if not connection:
         return None
 

--- a/eduvpn/ui/stats.py
+++ b/eduvpn/ui/stats.py
@@ -14,6 +14,7 @@ LINUX_NET_FOLDER = Path("/sys/class/net")
 
 class NetworkStats:
 
+    _timestamp = None
     default_text = translated_property("N/A")
 
     # These properties define an LRU cache
@@ -60,9 +61,11 @@ class NetworkStats:
         return get_iface()
 
     @property  # type: ignore
-    @cache
     def timestamp(self) -> Optional[int]:
-        return get_timestamp()
+        # 0 or None, try again
+        if not self._timestamp:
+            self._timestamp = get_timestamp()
+        return self._timestamp
 
     @property
     def download(self) -> str:
@@ -93,7 +96,7 @@ class NetworkStats:
         """
         Get the duration of the connection, in "HH:MM:SS"
         """
-        if self.timestamp is None:
+        if not self.timestamp:
             logger.warning("Network Stats: failed to get timestamp")
             return self.default_text
         now_unix_seconds = int(time.time())


### PR DESCRIPTION
The duration was really buggy, sometimes it shows the duration since 1st january 1970, since NM can return 0. Additionally, the duration is not reset upon disconnect+connect again with the toggle. This pr fixes that by making sure we use the connection with the saved connection id and we retry the timestamp when networkmanager returns 0. If network manager still returns 0 (or None), we show N/A in the UI.