### PR TITLE
Make tests pass when running with NetworkManager

### DIFF
--- a/tests/test_nm.py
+++ b/tests/test_nm.py
@@ -14,7 +14,7 @@ class TestNm(TestCase):
 
     def test_import_ovpn(self):
         ovpn = Ovpn.parse(mock_config)
-        import_ovpn(ovpn, mock_key, mock_cert)
+        import_ovpn(ovpn)
 
     def test_get_mainloop(self):
         get_mainloop()
@@ -22,7 +22,7 @@ class TestNm(TestCase):
     def test_get_add_connection(self):
         client = get_client()
         ovpn = Ovpn.parse(mock_config)
-        simple_connection = import_ovpn(ovpn, mock_key, mock_cert)
+        simple_connection = import_ovpn(ovpn)
         add_connection(client, simple_connection)
 
     def test_get_uuid(self):

--- a/tests/test_nm.py
+++ b/tests/test_nm.py
@@ -4,7 +4,7 @@ from eduvpn.nm import (nm_available, add_connection,
                        import_ovpn, get_client, get_mainloop)
 from eduvpn.ovpn import Ovpn
 from eduvpn.storage import get_uuid
-from tests.mock_config import mock_config, mock_key, mock_cert
+from tests.mock_config import mock_config
 
 
 @skipIf(not nm_available(), "Network manager not available")


### PR DESCRIPTION
Tests would fail with


```python
______________________________________________________________ TestNm.test_get_add_connection ______________________________________________________________

self = <tests.test_nm.TestNm testMethod=test_get_add_connection>

    def test_get_add_connection(self):
        client = get_client()
        ovpn = Ovpn.parse(mock_config)
>       simple_connection = import_ovpn(ovpn, mock_key, mock_cert)
E       TypeError: import_ovpn() takes 1 positional argument but 3 were given

tests/test_nm.py:25: TypeError
_________________________________________________________________ TestNm.test_import_ovpn __________________________________________________________________

self = <tests.test_nm.TestNm testMethod=test_import_ovpn>

    def test_import_ovpn(self):
        ovpn = Ovpn.parse(mock_config)
>       import_ovpn(ovpn, mock_key, mock_cert)
E       TypeError: import_ovpn() takes 1 positional argument but 3 were given

tests/test_nm.py:17: TypeError


```

When testing with a device that uses NetworkManager

Note that `mock_key` and `mock_cert` is unused now, but it is in commented code in the tests still https://github.com/eduvpn/python-eduvpn-client/blob/9435e9d1d16aa528fca78def71bf9a7264fe1398/tests/test_nm.py#L38