### PR TITLE
Connection Info: Remove duration and down/up fixes

### DIFF
--- a/eduvpn/ui/stats.py
+++ b/eduvpn/ui/stats.py
@@ -1,10 +1,8 @@
 import logging
-import time
-from datetime import timedelta
 from pathlib import Path
 from typing import Optional, TextIO
 
-from ..nm import get_iface, get_ipv4, get_ipv6, get_timestamp
+from ..nm import get_iface, get_ipv4, get_ipv6
 from ..utils import cache, get_human_readable_bytes, translated_property
 
 logger = logging.getLogger(__name__)
@@ -14,7 +12,6 @@ LINUX_NET_FOLDER = Path("/sys/class/net")
 
 class NetworkStats:
 
-    _timestamp = None
     default_text = translated_property("N/A")
 
     # These properties define an LRU cache
@@ -60,13 +57,6 @@ class NetworkStats:
     def iface(self) -> Optional[str]:
         return get_iface()
 
-    @property  # type: ignore
-    def timestamp(self) -> Optional[int]:
-        # 0 or None, try again
-        if not self._timestamp:
-            self._timestamp = get_timestamp()
-        return self._timestamp
-
     @property
     def download(self) -> str:
         """
@@ -90,18 +80,6 @@ class NetworkStats:
         if file_bytes_upload <= self.start_bytes_upload:  # type: ignore
             return get_human_readable_bytes(0)
         return get_human_readable_bytes(file_bytes_upload - self.start_bytes_upload)  # type:ignore
-
-    @property
-    def duration(self) -> str:
-        """
-        Get the duration of the connection, in "HH:MM:SS"
-        """
-        if not self.timestamp:
-            logger.warning("Network Stats: failed to get timestamp")
-            return self.default_text
-        now_unix_seconds = int(time.time())
-        duration = now_unix_seconds - self.timestamp  # type: ignore
-        return str(timedelta(seconds=duration))
 
     def open_file(self, filename: str) -> Optional[TextIO]:
         """

--- a/share/eduvpn/builder/mainwindow.ui
+++ b/share/eduvpn/builder/mainwindow.ui
@@ -757,7 +757,7 @@
                             <property name="can-focus">False</property>
                             <property name="left-padding">12</property>
                             <child>
-                              <!-- n-columns=4 n-rows=5 -->
+                              <!-- n-columns=4 n-rows=4 -->
                               <object class="GtkGrid">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -773,35 +773,6 @@
                                     <property name="can-focus">False</property>
                                     <property name="halign">start</property>
                                     <property name="hexpand">True</property>
-                                    <property name="label" translatable="yes">Duration</property>
-                                    <attributes>
-                                      <attribute name="weight" value="semibold"/>
-                                    </attributes>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">0</property>
-                                    <property name="top-attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="connectionInfoDurationText">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="hexpand">True</property>
-                                    <property name="label" translatable="yes">N/A</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="top-attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="hexpand">True</property>
                                     <property name="label" translatable="yes">Downloaded</property>
                                     <attributes>
                                       <attribute name="weight" value="semibold"/>
@@ -809,7 +780,7 @@
                                   </object>
                                   <packing>
                                     <property name="left-attach">0</property>
-                                    <property name="top-attach">1</property>
+                                    <property name="top-attach">0</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -822,7 +793,7 @@
                                   </object>
                                   <packing>
                                     <property name="left-attach">1</property>
-                                    <property name="top-attach">1</property>
+                                    <property name="top-attach">0</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -838,7 +809,7 @@
                                   </object>
                                   <packing>
                                     <property name="left-attach">2</property>
-                                    <property name="top-attach">1</property>
+                                    <property name="top-attach">0</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -851,7 +822,7 @@
                                   </object>
                                   <packing>
                                     <property name="left-attach">3</property>
-                                    <property name="top-attach">1</property>
+                                    <property name="top-attach">0</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -867,7 +838,7 @@
                                   </object>
                                   <packing>
                                     <property name="left-attach">0</property>
-                                    <property name="top-attach">3</property>
+                                    <property name="top-attach">2</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -883,7 +854,7 @@
                                   </object>
                                   <packing>
                                     <property name="left-attach">2</property>
-                                    <property name="top-attach">3</property>
+                                    <property name="top-attach">2</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -896,8 +867,8 @@
                                   </object>
                                   <packing>
                                     <property name="left-attach">0</property>
-                                    <property name="top-attach">4</property>
                                     <property name="width">2</property>
+                                    <property name="top-attach">3</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -910,8 +881,8 @@
                                   </object>
                                   <packing>
                                     <property name="left-attach">2</property>
-                                    <property name="top-attach">4</property>
                                     <property name="width">2</property>
+                                    <property name="top-attach">3</property>
                                   </packing>
                                 </child>
                                 <child>


### PR DESCRIPTION
- download/upload: No longer gets reset upon expander toggle
- download/upload: Wireguard support
- Duration: removed due to inability to get it working. Nm's timestamp
 is NOT the time the connection was last set to connected, it gets
 updated periodically. There is no simple way to implement this properly without some NetworkManager statistic, which I can't find.

Reported by @fkooman