### PR TITLE
NM: Make connections optionally user only

### DIFF
--- a/eduvpn/config.py
+++ b/eduvpn/config.py
@@ -13,6 +13,7 @@ CONFIG_PATH = CONFIG_PREFIX / CONFIG_FILE_NAME
 
 DEFAULT_SETTINGS = dict(
     force_tcp=False,
+    nm_user_only=False,
 )
 
 
@@ -63,3 +64,4 @@ class Configuration:
             self.save()
 
     force_tcp = SettingDescriptor[bool]()
+    nm_user_only = SettingDescriptor[bool]()

--- a/eduvpn/ui/ui.py
+++ b/eduvpn/ui/ui.py
@@ -97,6 +97,7 @@ class EduVpnGtkWindow(Gtk.ApplicationWindow):
             "on_acknowledge_error": self.on_acknowledge_error,
             "on_renew_session_clicked": self.on_renew_session_clicked,
             "on_config_force_tcp": self.on_config_force_tcp,
+            "on_config_nm_user_only": self.on_config_nm_user_only,
             "on_close_window": self.on_close_window,
         }
         builder.connect_signals(handlers)
@@ -155,6 +156,7 @@ class EduVpnGtkWindow(Gtk.ApplicationWindow):
 
         self.settings_page = builder.get_object('settingsPage')
         self.setting_config_force_tcp = builder.get_object('settingConfigForceTCP')
+        self.setting_config_nm_user_only = builder.get_object('settingConfigNMUserOnly')
 
         self.loading_page = builder.get_object('loadingPage')
         self.loading_title = builder.get_object('loadingTitle')
@@ -237,6 +239,7 @@ class EduVpnGtkWindow(Gtk.ApplicationWindow):
     def enter_settings_page(self):
         assert not self.is_on_settings_page()
         self.setting_config_force_tcp.set_state(self.app.config.force_tcp)
+        self.setting_config_nm_user_only.set_state(self.app.config.nm_user_only)
         self.page_stack.set_visible_child(self.settings_page)
         self.show_back_button(True)
 
@@ -699,6 +702,10 @@ class EduVpnGtkWindow(Gtk.ApplicationWindow):
     def on_config_force_tcp(self, switch, state: bool):
         logger.debug("clicked on setting: 'force tcp'")
         self.app.config.force_tcp = state
+
+    def on_config_nm_user_only(self, switch, state: bool):
+        logger.debug("clicked on setting: 'nm user only'")
+        self.app.config.nm_user_only = state
 
     def on_close_window(self, window, event):
         logger.debug("clicked on close window")

--- a/share/eduvpn/builder/mainwindow.ui
+++ b/share/eduvpn/builder/mainwindow.ui
@@ -1068,22 +1068,10 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox">
+                  <!-- n-columns=2 n-rows=2 -->
+                  <object class="GtkGrid">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="label" translatable="yes">Force TCP</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
                     <child>
                       <object class="GtkSwitch" id="settingConfigForceTCP">
                         <property name="visible">True</property>
@@ -1093,16 +1081,52 @@
                         <signal name="state-set" handler="on_config_force_tcp" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Force TCP</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Only the current user may connect to the network</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSwitch" id="settingConfigNMUserOnly">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="halign">end</property>
+                        <property name="hexpand">True</property>
+                        <signal name="state-set" handler="on_config_nm_user_only" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>


### PR DESCRIPTION
This adds an option so that connections are configured for the current user only instead of system-wide.
Fixes #488 

Disabled by default because this is also what networkmanager does