### PR TITLE
Fix server info launch

### DIFF
--- a/eduvpn/app.py
+++ b/eduvpn/app.py
@@ -61,6 +61,7 @@ class Application:
             else:
                 validity = storage.get_current_validity(server.oauth_login_url)
                 self.session_transition('found_active_session', server, validity)
+                self.network_transition('found_previous_connection')
         else:
             self.session_transition('no_previous_session_found')
 

--- a/eduvpn/session.py
+++ b/eduvpn/session.py
@@ -94,7 +94,6 @@ class InitialSessionState(SessionState):
         """
         An already active session was found.
         """
-        app.network_transition('found_previous_connection')
         return self.new_session(app, server, validity)
 
     def no_previous_session_found(self, app: Application) -> SessionState:


### PR DESCRIPTION
The state transition was done before we returned the right state (`SessionActiveState`)

Fixes #496 