### PR TITLE
Prepare 3.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,18 @@
+3.1.0 (2022-06-23)
+==
+
+Additions
+--------
+* #489 Make NetworkManager connections optionally for the current user only by @jwijenbergh. This can get rid of authentication popups depending on your polkit settings
+* #490 Add a quick note for the AUR package by @jwijenbergh
+
+Bugfixes
+--------
+* #491 Refactor selections by @jwijenbergh. This fixes profiles/servers being selected automatically
+* #494 Simplify getting interface/IP info and fix inconsistencies by @jwijenbergh. This gives a more accurate way to get the network interface across all systems
+* #495 Cleanup network states by @jwijenbergh. This makes sure that we use the right connection for state updates, which fixes bugs when using eduVPN with another VPN/Connection. Additionally it fixes a major bug with reconnecting when using OpenVPN
+* #497 Fix server info launch by @jwijenbergh. This guarantees that server info is correctly displayed when launching the app with an active eduVPN connection
+
 3.0.0 (2022-05-09)
 ===
 

--- a/eduvpn.spec
+++ b/eduvpn.spec
@@ -2,7 +2,7 @@
 %global sum client for eduVPN
 
 Name:           eduvpn_client
-Version:        3.0.0
+Version:        3.1.0
 Release:        1%{?dist}
 Summary:        %{sum}
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from glob import glob
 
 from setuptools import setup, find_packages
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
IMO 3.1 should be released asap. Some issues are still left open with the 3.1 milestone but these are better fit for future releases where we use the Go library.

3.1 and not 3.0.1 because there are enough changes and the Windows client will release 3.1 soon too