### PR TITLE
Server: Add handling for unknown keyword arguments

### DIFF
--- a/eduvpn/server.py
+++ b/eduvpn/server.py
@@ -292,6 +292,7 @@ class Profile:
                  display_name: TranslatedStr,
                  default_gateway: Optional[bool] = None,
                  vpn_proto_list: Iterable[str] = frozenset('openvpn'),
+                 **kwargs
                  ):
         self.profile_id = profile_id
         self.display_name = display_name


### PR DESCRIPTION
- This fixes backwards compatibility with older servers that
e.g. still have `vpn_proto_preferred`

Fixes #499 