### PR TITLE
Remove deprecated usage of apt-key

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -28,9 +28,9 @@ You can install the latest release on Debian or Ubuntu using the eduVPN packagin
 
 .. code-block:: console
 
-    $ sudo apt install apt-transport-https curl
-    $ curl -L https://app.eduvpn.org/linux/deb/eduvpn.key | sudo apt-key add -
-    $ echo "deb https://app.eduvpn.org/linux/deb/ stable main" | sudo tee -a /etc/apt/sources.list.d/eduvpn.list
+    $ sudo apt install apt-transport-https wget
+    $ wget -O- https://app.eduvpn.org/linux/deb/eduvpn.key | gpg --dearmor | sudo tee /usr/share/keyrings/eduvpn.gpg
+    $ echo "deb [signed-by=/usr/share/keyrings/eduvpn.gpg] https://app.eduvpn.org/linux/deb/ stable main" | sudo tee -a /etc/apt/sources.list.d/eduvpn.list
     $ sudo apt update
     $ sudo apt install eduvpn-client
 


### PR DESCRIPTION
Fixes #501.

apt-key has been deprecated and should no longer be used, as it poses a security threat to users. Instead, the key should be added to a separate keyring, and the source repository should be configured to use that key. I have explained the issue and solution in more detail [in a post on StackOverflow](https://stackoverflow.com/a/71384057/). See also [the explanation on the Debian Wiki](https://wiki.debian.org/DebianRepository/UseThirdParty#OpenPGP_Key_distribution), [this article](https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html), [this AskUbuntu answer](https://askubuntu.com/a/1307181),  and  [see how Signal uses it](https://signal.org/download/).
