### PR TITLE
Config + NM + UI: Set connection to user only by default

### DIFF
--- a/eduvpn/config.py
+++ b/eduvpn/config.py
@@ -13,7 +13,7 @@ CONFIG_PATH = CONFIG_PREFIX / CONFIG_FILE_NAME
 
 DEFAULT_SETTINGS = dict(
     force_tcp=False,
-    nm_user_only=False,
+    nm_system_wide=False,
 )
 
 
@@ -64,4 +64,4 @@ class Configuration:
             self.save()
 
     force_tcp = SettingDescriptor[bool]()
-    nm_user_only = SettingDescriptor[bool]()
+    nm_system_wide = SettingDescriptor[bool]()

--- a/eduvpn/nm.py
+++ b/eduvpn/nm.py
@@ -238,9 +238,9 @@ def update_connection(old_con: 'NM.Connection', new_con: 'NM.Connection', callba
                                  user_data=callback)
 
 
-def set_connection(client, new_connection, callback, user_only=False):
+def set_connection(client, new_connection, callback, system_wide=False):
     uuid = get_uuid()
-    new_connection = set_setting_ensure_permissions(new_connection, user_only)
+    new_connection = set_setting_ensure_permissions(new_connection, not system_wide)
     if uuid:
         old_con = client.get_connection_by_uuid(uuid)
         if old_con:
@@ -257,10 +257,10 @@ def set_setting_ensure_permissions(con: 'NM.SimpleConnection', enable: bool) -> 
     return con
 
 
-def save_connection(client: 'NM.Client', ovpn: Ovpn, private_key, certificate, callback=None, user_only=False):
+def save_connection(client: 'NM.Client', ovpn: Ovpn, private_key, certificate, callback=None, system_wide=False):
     _logger.info("writing configuration to Network Manager")
     new_con = import_ovpn_and_certificate(ovpn, private_key, certificate)
-    set_connection(client, new_con, callback, user_only)
+    set_connection(client, new_con, callback, system_wide)
 
 
 def save_connection_with_config(client: 'NM.Client',
@@ -273,7 +273,7 @@ def save_connection_with_config(client: 'NM.Client',
     settings = Configuration.load()
     if settings.force_tcp:
         ovpn.force_tcp()
-    return save_connection(client, ovpn, private_key, certificate, callback, settings.nm_user_only)
+    return save_connection(client, ovpn, private_key, certificate, callback, settings.nm_system_wide)
 
 
 def start_openvpn_connection(ovpn: Ovpn, *, callback=None):
@@ -281,7 +281,7 @@ def start_openvpn_connection(ovpn: Ovpn, *, callback=None):
     _logger.info("writing ovpn configuration to Network Manager")
     new_con = import_ovpn(ovpn)
     settings = Configuration.load()
-    set_connection(client, new_con, callback, settings.nm_user_only)
+    set_connection(client, new_con, callback, settings.nm_system_wide)
 
 
 def start_wireguard_connection(
@@ -364,7 +364,7 @@ def start_wireguard_connection(
     profile.add_setting(w_con)
 
     settings = Configuration.load()
-    set_connection(client, profile, callback, settings.nm_user_only)
+    set_connection(client, profile, callback, settings.nm_system_wide)
 
 
 def get_cert_key(client: 'NM.Client', uuid: str) -> Tuple[str, str]:

--- a/eduvpn/ui/ui.py
+++ b/eduvpn/ui/ui.py
@@ -97,7 +97,7 @@ class EduVpnGtkWindow(Gtk.ApplicationWindow):
             "on_acknowledge_error": self.on_acknowledge_error,
             "on_renew_session_clicked": self.on_renew_session_clicked,
             "on_config_force_tcp": self.on_config_force_tcp,
-            "on_config_nm_user_only": self.on_config_nm_user_only,
+            "on_config_nm_system_wide": self.on_config_nm_system_wide,
             "on_close_window": self.on_close_window,
         }
         builder.connect_signals(handlers)
@@ -156,7 +156,7 @@ class EduVpnGtkWindow(Gtk.ApplicationWindow):
 
         self.settings_page = builder.get_object('settingsPage')
         self.setting_config_force_tcp = builder.get_object('settingConfigForceTCP')
-        self.setting_config_nm_user_only = builder.get_object('settingConfigNMUserOnly')
+        self.setting_config_nm_system_wide = builder.get_object('settingConfigNMSystemWide')
 
         self.loading_page = builder.get_object('loadingPage')
         self.loading_title = builder.get_object('loadingTitle')
@@ -239,7 +239,7 @@ class EduVpnGtkWindow(Gtk.ApplicationWindow):
     def enter_settings_page(self):
         assert not self.is_on_settings_page()
         self.setting_config_force_tcp.set_state(self.app.config.force_tcp)
-        self.setting_config_nm_user_only.set_state(self.app.config.nm_user_only)
+        self.setting_config_nm_system_wide.set_state(self.app.config.nm_system_wide)
         self.page_stack.set_visible_child(self.settings_page)
         self.show_back_button(True)
 
@@ -685,9 +685,9 @@ class EduVpnGtkWindow(Gtk.ApplicationWindow):
         logger.debug("clicked on setting: 'force tcp'")
         self.app.config.force_tcp = state
 
-    def on_config_nm_user_only(self, switch, state: bool):
-        logger.debug("clicked on setting: 'nm user only'")
-        self.app.config.nm_user_only = state
+    def on_config_nm_system_wide(self, switch, state: bool):
+        logger.debug("clicked on setting: 'nm system wide'")
+        self.app.config.nm_system_wide = state
 
     def on_close_window(self, window, event):
         logger.debug("clicked on close window")

--- a/share/eduvpn/builder/mainwindow.ui
+++ b/share/eduvpn/builder/mainwindow.ui
@@ -1101,7 +1101,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="label" translatable="yes">Only the current user may connect to the network</property>
+                        <property name="label" translatable="yes">All users may connect to the VPN network</property>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -1109,12 +1109,12 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkSwitch" id="settingConfigNMUserOnly">
+                      <object class="GtkSwitch" id="settingConfigNMSystemWide">
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="halign">end</property>
                         <property name="hexpand">True</property>
-                        <signal name="state-set" handler="on_config_nm_user_only" swapped="no"/>
+                        <signal name="state-set" handler="on_config_nm_system_wide" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>


### PR DESCRIPTION
Fixes #504 

Forces nm to set system wide to `False`, thus only giving permission to the current user only. Users can still enable this in the settings. I renamed the setting to be more in line with networkmanager and to also give new users the new setting by default for security.