### PR TITLE
Add Category to desktop files

### DIFF
--- a/eduvpn/data/share/applications/org.eduvpn.client.desktop
+++ b/eduvpn/data/share/applications/org.eduvpn.client.desktop
@@ -7,4 +7,4 @@ Exec=eduvpn-gui
 Icon=org.eduvpn.client
 Terminal=false
 StartupWMClass=org.eduvpn.client
-
+Categories=Network;Dialup

--- a/eduvpn/data/share/applications/org.letsconnect-vpn.client.desktop
+++ b/eduvpn/data/share/applications/org.letsconnect-vpn.client.desktop
@@ -7,4 +7,4 @@ Exec=letsconnect-gui
 Icon=org.letsconnect-vpn.client
 Terminal=false
 StartupWMClass=org.letsconnect-vpn.client
-
+Categories=Network;Dialup


### PR DESCRIPTION
During packaging eduVPN for Gentoo Linux the distro maintainers suggested to add the category `Network;Dialup` to the desktop file. Currently we are applying this patch downstream, but it may be useful for other users, too. So I would like to request you considering to apply this patch upstream.