### PR TITLE
Configurable renew delay

### DIFF
--- a/eduvpn/app.py
+++ b/eduvpn/app.py
@@ -458,6 +458,7 @@ class ApplicationModel:
                 if callback:
                     callback(False)
                 return
+            time.sleep(int(os.getenv("EDUVPN_RENEW_DELAY", "1")))
             # Delete the OAuth access and refresh token
             # Start the OAuth authorization flow
             self.common.renew_session()

--- a/eduvpn/cli.py
+++ b/eduvpn/cli.py
@@ -731,3 +731,7 @@ def letsconnect():
     _common = common.EduVPN(LETSCONNECT_CLIENT_ID, __version__, str(LETSCONNECT_CONFIG_PREFIX))
     cmd = CommandLine("Let's Connect!", LETS_CONNECT, _common)
     cmd.start()
+
+
+if __name__ == "__main__":
+    eduvpn()


### PR DESCRIPTION
I am getting a report that renewing times out. This is strange! What if
we delay after disconnecting? Let's try by default 1 second